### PR TITLE
Adds target to the gacha and spark commands.

### DIFF
--- a/resources/startup.pgsql
+++ b/resources/startup.pgsql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS sparks (
     crystals INTEGER DEFAULT 0,
     tickets INTEGER DEFAULT 0,
     ten_tickets INTEGER DEFAULT 0,
-    target TEXT,
+    target_id uuid,
     last_updated TIMESTAMP DEFAULT current_timestamp
 );
 


### PR DESCRIPTION
This should add the following functionality:

* User should be able to set a target with their spark progress data
* When a user uses the gacha command, if they get their spark target, it should be highlighted in the spark summary.
* There should be a new command that allows the user to tell Siero to draw until their target is reached, outputting how many draws it took.