### PR TITLE
Siero sometimes wasn't editing messages

### DIFF
--- a/commands/gacha.js
+++ b/commands/gacha.js
@@ -188,7 +188,12 @@ class GachaCommand extends Command {
                     content: `\`\`\`${message.content} ${appearance}\`\`\``
                 }
 
-                common.reportError(this.message, this.userId, this.context, error, text, false, section)
+                if (this.duplicateMessage != null) {
+                    common.reportError(this.message, this.userId, this.context, error, text, false, section, this.duplicateMessage)
+                    this.duplicateMessage = null
+                } else {
+                    common.reportError(this.message, this.userId, this.context, error, text, false, section)
+                }   
             }
         }
     }
@@ -433,6 +438,7 @@ class GachaCommand extends Command {
                     var message
                     if (this.duplicateMessage != null) {
                         message = this.duplicateMessage.edit(embed)
+                        this.duplicateMessage = null
                     } else {
                         message = this.message.channel.send(embed)
                     }

--- a/commands/gacha.js
+++ b/commands/gacha.js
@@ -449,6 +449,10 @@ class GachaCommand extends Command {
 
                     return decision.receiveSelection(message, this.userId)
                 }).then(selection => {
+                    if (this.duplicateMessage.channel.type !== 'dm') {
+                        this.duplicateMessage.reactions.removeAll().catch(error => console.error('Failed to clear reactions: ', error))
+                    }
+                    
                     return results[selection]
                 }).catch(error => {
                     let text = 'Sorry, there was an error communicating with the database for your last request.'

--- a/helpers/common.js
+++ b/helpers/common.js
@@ -102,17 +102,20 @@ module.exports = {
         
         this.reportError(message, userId, context, error, text, false, section)
     },
-    reportError: function(message, userId, context, error, responseText, showDescription = false, extraSection = null) {                
+    reportError: function(message, userId, context, error, responseText, showDescription = false, extraSection = null, editableMessage = null) {                
         let response = this.buildHelpfulResponse(message, responseText, context, showDescription, extraSection)
         
-        message.author.send(response)
-            .catch(function(error) {
-                if (error instanceof DiscordAPIError) {
-                    console.log(`Cannot send private messages to this user: ${userId}`)
-                    message.reply("There was an error, but it looks like I'm not allowed to send you direct messages! Check your Discord privacy settings if you'd like help with commands via DM.")
-
-                }
-            })
+        if (editableMessage != null) {
+            editableMessage.edit(response)
+        } else {
+            message.author.send(response)
+                .catch(function(error) {
+                    if (error instanceof DiscordAPIError) {
+                        console.log(`Cannot send private messages to this user: ${userId}`)
+                        message.reply("There was an error, but it looks like I'm not allowed to send you direct messages! Check your Discord privacy settings if you'd like help with commands via DM.")
+                    }
+                })
+        }
         
         if (!error instanceof pgpErrors.QueryResultError) {
             console.log(error)

--- a/helpers/decision.js
+++ b/helpers/decision.js
@@ -112,7 +112,7 @@ module.exports = {
                 })
                 .catch(error => {
                     console.log(error)
-                    message.reply('You didn\'t react with a valid emoji.');
+                    message.channel.send('You didn\'t react with a valid emoji.');
                 })
         } catch (error) {
             console.log(error)


### PR DESCRIPTION
## Overview
In some cases, we want Siero to edit messages to give the user updated information about their query. In some cases, this was broken.

## Testing

Add test cases and check the boxes to confirm you have manually confirmed the following cases.
- [x] In a channel with Siero, send `$gacha until jeanne`. Observe she responds with a list of results
- [x] Select _Orleans Standard_. Observe that Siero edits the message to say that item is unavailable in the selected gala or season.
- [x] Observe that the reactions on the previous message are removed if in a public channel.
- [x] In the same channel, send `$gacha until medusa`. Observe that the item chooser is sent in a new message.
- [x] Without selecting anything, wait for the request to time out. Observe that Siero mentions the correct user.
