### PR TITLE
Add a way to see total servers and users

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 
 const { AkairoClient, CommandHandler, ListenerHandler } = require('discord-akairo')
+const pluralize = require('pluralize')
 
 class SieroClient extends AkairoClient {
     constructor() {
@@ -26,3 +27,8 @@ class SieroClient extends AkairoClient {
 
 const client = new SieroClient()
 client.login(process.env.DISCORD_SECRET)
+
+client.once('ready', () => {
+    console.log('Siero is online!')
+    console.log(`Currently running for ${client.users.cache.size} ${pluralize('user', client.users.cache.size)} in ${client.guilds.cache.size} ${pluralize('server', client.guilds.cache.size)}.`)
+})

--- a/src/commands/admin.ts
+++ b/src/commands/admin.ts
@@ -1,0 +1,22 @@
+import { Message } from "discord.js"
+
+const { Command } = require('discord-akairo')
+
+const pluralize = require('pluralize')
+
+class AdminCommand extends Command {
+    constructor() {
+        super('admin', {
+            aliases: ['admin']
+        })
+    }
+
+    exec(message: Message) {
+        if (message.author.id === '139468879008235520') {
+            const stats = `Currently running for ${this.client.users.cache.size} ${pluralize('user', this.client.users.cache.size)} in ${this.client.guilds.cache.size} ${pluralize('server', this.client.guilds.cache.size)}.`
+            message.channel.send(stats)
+        }
+    }
+}
+
+module.exports = AdminCommand


### PR DESCRIPTION
## Overview
Adds a log once the bot is ready and a command that shows the total number of users and guilds that Siero is installed across.

## Testing
- [ ] Run the bot, it should say that it's online and how many users and servers it's running on.
- [ ] Change the hardcoded id in `admin.ts` to your Discord ID and run `$admin`. It should say how many users and servers the bot is running on.