### PR TITLE
Generate leaderboard based on the guilds member list (Issue #44)

### DIFF
--- a/src/commands/spark.ts
+++ b/src/commands/spark.ts
@@ -1,5 +1,7 @@
 import { Message } from 'discord.js'
 import { MessageEmbed } from 'discord.js'
+import { GuildMember } from 'discord.js'
+import { Snowflake } from 'discord.js'
 
 const { Client, pgpErrors } = require('../services/connection.js')
 const { Command } = require('discord-akairo')
@@ -66,10 +68,6 @@ class SparkCommand extends Command {
                 }
 
                 return
-            }).then(() => {
-                if (message.channel.type !== 'dm') {
-                    this.checkGuildAssociation(this.commandType)
-                }
             }).then(() => {
                 this.switchOperation(args)
             })
@@ -210,8 +208,9 @@ class SparkCommand extends Command {
             this.invalidContext()
             return
         }
-
-        let leaderboard = new Leaderboard(this.message.guild.id, order)
+        
+        let memberIds: Snowflake[] = (await this.message.guild.members.fetch()).map((g: GuildMember) => g.id);
+        let leaderboard = new Leaderboard(memberIds, order)
         await leaderboard.fetchData()
             .then((embed: string) => {
                 this.message.channel.send(embed)
@@ -472,38 +471,6 @@ class SparkCommand extends Command {
         } catch(error) {
             console.error(error)
         }
-    }
-
-    private checkGuildAssociation(table: string) {
-        let sql = [
-            `SELECT user_id, guild_ids FROM ${table}`,
-            'WHERE user_id = $1',
-            'LIMIT 1'
-        ].join(' ')
-
-        Client.one(sql, this.userId)
-            .then((result: StringResult) => {
-                let guilds = result.guild_ids
-                if (!guilds || guilds && !guilds.includes(this.message.guild.id)) {
-                    this.createGuildAssociation(table)
-                }
-            })
-            .catch((error: Error) => {
-                console.error(error)
-            })
-    }
-
-    private createGuildAssociation(table: string) {
-        let sql = [
-            `UPDATE ${table}`,
-            'SET guild_ids = array_cat(guild_ids, $1)',
-            'WHERE user_id = $2'
-        ].join(' ')
-
-        Client.any(sql, ['{' + this.message.guild.id + '}', this.userId])
-            .catch((error: Error) => {
-                console.error(error)
-            })
     }
 
     // Render methods

--- a/src/resources/dbupdate_v2.0.pgsql
+++ b/src/resources/dbupdate_v2.0.pgsql
@@ -1,0 +1,1 @@
+ALTER TABLE sparks DROP COLUMN guild_ids;

--- a/src/resources/startup.pgsql
+++ b/src/resources/startup.pgsql
@@ -2,7 +2,6 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CREATE TABLE IF NOT EXISTS sparks (
     user_id TEXT PRIMARY KEY,
-    guild_ids TEXT[],
     username TEXT,
     crystals INTEGER DEFAULT 0,
     tickets INTEGER DEFAULT 0,


### PR DESCRIPTION
## Overview
**Issue:** https://github.com/jedmund/siero-bot/issues/44

Leader/Loserboard are now generated based on the member list of the guild where the command was invoked. This involves minor changes to the leaderboard constructor and query. 
As tracking a users guilds is no longer necessary, the relevant columns / methods have been removed. 

## Testing

Add test cases and check the boxes to confirm you have manually confirmed the following cases.
- [X] `$spark leaderboard` provides the expected result
- [X] `$spark loserboard` provides the expected result
![Discord_2020-06-01_17-32-49](https://user-images.githubusercontent.com/4991764/83426958-46b6ec00-a430-11ea-8127-ce0ec32ae7c3.png)

