### PR TITLE
ISSUE-5: Add a basic $schedule

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -24,6 +24,8 @@ Roll the virtual gacha\n
 Save useful information in your profile or see someone else's\n
 <$spark $s> 
 Log your progress while saving a spark\n
+<$schedule $sc> 
+Show the upcoming schedule in Granblue Fantasy\n
 <$sticker $ss>
 Use a Granblue sticker in Discord\`\`\``)
         embed.addField("Even more help", `You can get help on any of the above commands by typing \`help\` after the command, like so: 

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -91,6 +91,9 @@ class ScheduleCommand extends Command {
                 this.current()
                 break
 
+            case 'help':
+                this.help()
+
             default:
                 break
         }
@@ -115,6 +118,42 @@ class ScheduleCommand extends Command {
         const event: Event = this.schedule.events[index]
         const embed: MessageEmbed = this.renderEvent(event)
 
+        this.message.channel.send(embed)
+    }
+
+    private help(): void {
+        let options = [
+            '```html\n',
+            '<show>',
+            'Show the upcoming schedule\n',
+            '<now>',
+            'Show the current event\n',
+            '<next>',
+            'Show the upcoming event```'
+        ].join('\n')
+
+        let link = 'https://github.com/jedmund/siero-bot/wiki/Viewing-the-schedule'
+
+        var embed = new MessageEmbed({
+            title: 'Schedule',
+            description: 'Welcome! I can tell you what events are coming up in Granblue Fantasy!',
+            color: 0xdc322f,
+            fields: [
+                {
+                    name: 'Command syntax',
+                    value: '```schedule <option>```'
+                },
+                {
+                    name: 'Schedule options',
+                    value: options
+                },
+                {
+                    name: 'Full documentation',
+                    value: link
+                }
+            ]
+        })
+    
         this.message.channel.send(embed)
     }
 

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -1,24 +1,55 @@
 
-import { Message, MessageEmbed } from 'discord.js'
+import { Message } from 'discord.js'
+import { MessageEmbed } from 'discord.js'
 import { Command } from 'discord-akairo'
 import { promises as fs } from 'fs'
 
-// import common from '../helpers/common.js'
+import common from '../helpers/common.js'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
+
 dayjs.extend(relativeTime)
 dayjs.extend(localizedFormat)
 
 const path = require('path')
 
+interface Event {
+    readonly [index: string]: string | LocalizedString | null
+    name: LocalizedString
+    type: string
+    starts: string
+    ends: string
+    advantage: string | null
+}
 
+interface Month {
+    month: string
+    period: string
+    events: {
+        en: string[]
+        jp: string[]
+    }
+}
+
+interface Schedule {
+    events: Event[]
+    scheduled: Month[]
+}
+
+interface LocalizedString {
+    en: string
+    jp: string
+}
 
 class ScheduleCommand extends Command {
-    schedule: { [key: string]: [ { [key: string]: string }] } = {}
     message: Message
+    schedule: Schedule = {
+        events: [],
+        scheduled: []
+    }
 
-    constructor() {
+    public constructor() {
         super('schedule', {
             aliases: ['schedule', 'sc'],
             args: [
@@ -32,8 +63,9 @@ class ScheduleCommand extends Command {
     }
 
     public async exec(message: Message, args: { operation: string }) {
-        this.message = message
         console.log(`(${dayjs().format('YYYY-MM-DD HH:mm:ss')}) [${message.author.id}] ${message.content}`)
+
+        common.storeMessage(this, message)
 
         await this.load()
             .then(() => {
@@ -46,12 +78,19 @@ class ScheduleCommand extends Command {
             case 'show':
                 this.show()
                 break
+
             case 'next':
                 this.next()
                 break
+
             case 'current':
                 this.current()
                 break
+
+            case 'now':
+                this.current()
+                break
+
             default:
                 break
         }
@@ -59,59 +98,82 @@ class ScheduleCommand extends Command {
 
     // Command methods
     private async show() {
-        let embed = this.renderSchedule()
+        const embed: MessageEmbed = this.renderSchedule()
         this.message.channel.send(embed)
     }
 
-    private next() {
-        const embed = this.renderEvent(this.schedule.events[1], false)
+    private next(): void {
+        const index: number = this.extractCurrentIndex() + 1
+        const event: Event = this.schedule.events[index]
+        const embed: MessageEmbed = this.renderEvent(event, false)
+
         this.message.channel.send(embed)
     }
 
-    private current() {
-        const embed = this.renderEvent(this.schedule.events[0])
+    private current(): void {
+        const index: number = this.extractCurrentIndex()
+        const event: Event = this.schedule.events[index]
+        const embed: MessageEmbed = this.renderEvent(event)
+
         this.message.channel.send(embed)
     }
 
     // File methods
-    private async load() {
-        const schedule = path.join(__dirname, '..', '..', '..', 'src', 'resources', 'schedule.json')
-        const data = await fs.readFile(schedule, 'utf8')
+    private async load(): Promise<void> {
+        const schedule: string = path.join(__dirname, '..', '..', '..', 'src', 'resources', 'schedule.json')
+        const data: string = await fs.readFile(schedule, 'utf8')
 
         this.schedule = JSON.parse(data)
     }
 
     // Render methods
-    private renderSchedule() {
-        let embed = new MessageEmbed({
+    private renderSchedule(): MessageEmbed {
+        const events: Event[] = this.schedule.events
+        
+        let embed: MessageEmbed = new MessageEmbed({
             title: 'Schedule'
         })
+
+        for (let i in events) {
+            let event: Event = events[i]
+            
+            const isCurrentEvent: boolean = (dayjs(event.starts).isBefore(dayjs()) && dayjs(event.ends).isAfter(dayjs()))
+            const startsString: string = `Starts ${dayjs().to(event.starts)}\n${dayjs(event.starts).format('LLLL')} JST`
+            const endsString: string = `Ends ${dayjs().to(event.ends)}\n${dayjs(event.ends).format('LLLL')} JST`
+            const dateString: string = (isCurrentEvent) ? endsString : startsString
+
+            let duration: string = `\`\`\`html${dateString}\`\`\``
+            embed.addField(event.name.en, duration)
+        }
 
         return embed
     }
 
-    private renderEvent(event: { [key: string]: string }, currentEvent: boolean = true) {
+    private renderEvent(event: Event, currentEvent: boolean = true): MessageEmbed {
         let embed = new MessageEmbed({
             color: 0xdc322f
         })
 
         const keys = Object.keys(event)
         for (var i = 0; i < keys.length; i++) {
-            const key = keys[i]
-            const readableKey = this.capitalize(keys[i].replace('-', ' '))
+            const key: string = keys[i]
+            const readableKey: string = this.capitalize(keys[i].replace('-', ' '))
 
             if (currentEvent && key !== 'starts') {
-                
+                // do nothing
             }
 
             if (!currentEvent && key === 'starts') {
-                const formattedTo = dayjs().to(event[key])
-                const formattedTime = dayjs(event[key]).format('LLLL')
+                const formattedTo: string = dayjs().to(event[key])
+                const formattedTime: string = dayjs(event[key]).format('LLLL')
+
                 embed.addField(`${readableKey} ${formattedTo}`, `${formattedTime} JST`)
             }
 
             if (key === 'banner') {
-                embed.setImage(event[key])
+                if (typeof event[key] === "string") {
+                    embed.setImage(event[key] as string)
+                }
             }
 
             if (key === 'name') {
@@ -123,26 +185,50 @@ class ScheduleCommand extends Command {
             }
             
             if (currentEvent && key === 'ends') {
-                const formattedTo = dayjs().to(event[key])
-                const formattedTime = dayjs(event[key]).format('LLLL')
+                const formattedTo: string = dayjs().to(event[key])
+                const formattedTime: string = dayjs(event[key]).format('LLLL')
+
                 embed.addField(`${readableKey} ${formattedTo}`, `${formattedTime} JST`)
             }
 
             if (!currentEvent && key === 'ends') {
-                const formattedTime = dayjs(event[key]).format('LLLL')
+                const formattedTime: string = dayjs(event[key]).format('LLLL')
                 embed.addField(readableKey, `${formattedTime} JST`)
             }
             
-            if (key === 'advantage') {
-                embed.addField(readableKey, this.capitalize(event[key]))
+            if (key === 'advantage' && event[key]) {
+                const advantage: string = event[key]!
+                embed.addField(readableKey, this.capitalize(advantage))
             }
         }
 
         return embed
     }
 
-    private capitalize(string: string) {
+    // Helper methods
+    private capitalize(string: string): string {
         return string.charAt(0).toUpperCase() + string.slice(1)
+    }
+
+    private extractCurrentIndex(): number {
+        let found: boolean = false
+        let n: number = 0
+
+        while (!found) {
+            const event: Event = this.schedule.events[n]
+
+            const startsBeforeNow: boolean = dayjs(event.starts).isBefore(dayjs())
+            const endsAfterNow: boolean = dayjs(event.ends).isAfter(dayjs())
+
+            if (startsBeforeNow && endsAfterNow) {
+                found = true
+                return n
+            }
+
+            n++
+        }
+
+        return n
     }
 }
 

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -1,0 +1,149 @@
+
+import { Message, MessageEmbed } from 'discord.js'
+import { Command } from 'discord-akairo'
+import { promises as fs } from 'fs'
+
+// import common from '../helpers/common.js'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import localizedFormat from 'dayjs/plugin/localizedFormat'
+dayjs.extend(relativeTime)
+dayjs.extend(localizedFormat)
+
+const path = require('path')
+
+
+
+class ScheduleCommand extends Command {
+    schedule: { [key: string]: [ { [key: string]: string }] } = {}
+    message: Message
+
+    constructor() {
+        super('schedule', {
+            aliases: ['schedule', 'sc'],
+            args: [
+                {
+                    id: 'operation',
+                    type: 'string',
+                    default: 'show'
+                }
+            ]
+        })
+    }
+
+    public async exec(message: Message, args: { operation: string }) {
+        this.message = message
+        console.log(`(${dayjs().format('YYYY-MM-DD HH:mm:ss')}) [${message.author.id}] ${message.content}`)
+
+        await this.load()
+            .then(() => {
+                this.switchOperation(args.operation)
+            })
+    }
+
+    private switchOperation(operation: string) {
+        switch (operation) {
+            case 'show':
+                this.show()
+                break
+            case 'next':
+                this.next()
+                break
+            case 'current':
+                this.current()
+                break
+            default:
+                break
+        }
+    }
+
+    // Command methods
+    private async show() {
+        let embed = this.renderSchedule()
+        this.message.channel.send(embed)
+    }
+
+    private next() {
+        const embed = this.renderEvent(this.schedule.events[1], false)
+        this.message.channel.send(embed)
+    }
+
+    private current() {
+        const embed = this.renderEvent(this.schedule.events[0])
+        this.message.channel.send(embed)
+    }
+
+    // File methods
+    private async load() {
+        const schedule = path.join(__dirname, '..', '..', '..', 'src', 'resources', 'schedule.json')
+        const data = await fs.readFile(schedule, 'utf8')
+
+        this.schedule = JSON.parse(data)
+    }
+
+    // Render methods
+    private renderSchedule() {
+        let embed = new MessageEmbed({
+            title: 'Schedule'
+        })
+
+        return embed
+    }
+
+    private renderEvent(event: { [key: string]: string }, currentEvent: boolean = true) {
+        let embed = new MessageEmbed({
+            color: 0xdc322f
+        })
+
+        const keys = Object.keys(event)
+        for (var i = 0; i < keys.length; i++) {
+            const key = keys[i]
+            const readableKey = this.capitalize(keys[i].replace('-', ' '))
+
+            if (currentEvent && key !== 'starts') {
+                
+            }
+
+            if (!currentEvent && key === 'starts') {
+                const formattedTo = dayjs().to(event[key])
+                const formattedTime = dayjs(event[key]).format('LLLL')
+                embed.addField(`${readableKey} ${formattedTo}`, `${formattedTime} JST`)
+            }
+
+            if (key === 'banner') {
+                embed.setImage(event[key])
+            }
+
+            if (key === 'name') {
+                embed.setTitle(event[key].en)
+            }
+            
+            if (key === 'type') {
+                embed.setAuthor(this.capitalize(event[key]))
+            }
+            
+            if (currentEvent && key === 'ends') {
+                const formattedTo = dayjs().to(event[key])
+                const formattedTime = dayjs(event[key]).format('LLLL')
+                embed.addField(`${readableKey} ${formattedTo}`, `${formattedTime} JST`)
+            }
+
+            if (!currentEvent && key === 'ends') {
+                const formattedTime = dayjs(event[key]).format('LLLL')
+                embed.addField(readableKey, `${formattedTime} JST`)
+            }
+            
+            if (key === 'advantage') {
+                embed.addField(readableKey, this.capitalize(event[key]))
+            }
+        }
+
+        return embed
+    }
+
+    private capitalize(string: string) {
+        return string.charAt(0).toUpperCase() + string.slice(1)
+    }
+}
+
+module.exports = ScheduleCommand

--- a/src/resources/schedule.json
+++ b/src/resources/schedule.json
@@ -38,7 +38,7 @@
             },
             "type": "guild-wars",
             "advantage": "fire",
-            "starts": "2020-06-20T7:00:00+09:00",
+            "starts": "2020-06-20T19:00:00+09:00",
             "ends": "2020-06-27T23:59:00+09:00"
         },
         {
@@ -47,7 +47,6 @@
                 "jp": "プレミウムフライデークエスト"
             },
             "type": "friday",
-            "advantage": "null",
             "starts": "2020-06-26T15:00:00+09:00",
             "ends": "2020-06-28T23:59:00+09:00"
         },
@@ -57,7 +56,6 @@
                 "jp": "シナリオイベント"
             },
             "type": "scenario",
-            "advantage": "unknown",
             "starts": "2020-06-28T17:00:00+09:00",
             "ends": "2020-07-06T18:59:00+09:00"
         }
@@ -80,29 +78,29 @@
     ],
     "scheduled": [
         {
-            "june": {
-                "period": "middle",
-                "events": {
-                    "en": [
-                        "New Class IV Job: Monk",
-                        "Treasure Trade Shop redesign"
-                    ],
-                    "jp": [
-                        "新クラスⅣジョブ「モンク」実装",
-                        "「ショップ」の「トレジャー交換」ページ改修"
-                    ]
-                }
-            },
-            "july": {
-                "period": "end",
-                "events": {
-                    "en": [
-                        "Main Story Quest update - 8 chapters"
-                    ],
-                    "jp": [
-                        "メインクエスト追加 - 8章"
-                    ]
-                }
+            "month": "june",
+            "period": "middle",
+            "events": {
+                "en": [
+                    "New Class IV Job: Monk",
+                    "Treasure Trade Shop redesign"
+                ],
+                "jp": [
+                    "新クラスⅣジョブ「モンク」実装",
+                    "「ショップ」の「トレジャー交換」ページ改修"
+                ]
+            }
+        },
+        {
+            "month": "july",
+            "period": "end",
+            "events": {
+                "en": [
+                    "Main Story Quest update - 8 chapters"
+                ],
+                "jp": [
+                    "メインクエスト追加 - 8章"
+                ]
             }
         }
     ]

--- a/src/resources/schedule.json
+++ b/src/resources/schedule.json
@@ -1,0 +1,109 @@
+{
+    "events": [
+        {
+            "name": {
+                "en": "The Doss! End of the Line Farewell Tour",
+                "jp": "The End of THE DOSS"
+            },
+            "banner": "https://gbf.wiki/images/6/6c/The_Doss%21_End_of_the_Line_Farewell_Tour_top.jpg",
+            "type": "scenario",
+            "advantage": "fire",
+            "starts": "2020-05-29T19:00:00+09:00",
+            "ends": "2020-06-06T20:59:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Rise of the Beasts",
+                "jp": "四象降臨"
+            },
+            "banner": "https://gbf.wiki/images/d/dd/Riseofthebeasts_top.png",
+            "type": "farming",
+            "starts": "2020-06-07T17:00:00+09:00",
+            "ends": "2020-06-14T20:59:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Xeno Ifrit Showdown",
+                "jp": "ゼノイフリート撃滅戦"
+            },
+            "type": "farming",
+            "advantage": "water",
+            "starts": "2020-06-13T17:00:00+09:00",
+            "ends": "2020-06-19T20:59:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Unite and Fight",
+                "jp": "決戦！星の古戦場 - 火有利"
+            },
+            "type": "guild-wars",
+            "advantage": "fire",
+            "starts": "2020-06-20T7:00:00+09:00",
+            "ends": "2020-06-27T23:59:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Premium Friday",
+                "jp": "プレミウムフライデークエスト"
+            },
+            "type": "friday",
+            "advantage": "null",
+            "starts": "2020-06-26T15:00:00+09:00",
+            "ends": "2020-06-28T23:59:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Scenario Event",
+                "jp": "シナリオイベント"
+            },
+            "type": "scenario",
+            "advantage": "unknown",
+            "starts": "2020-06-28T17:00:00+09:00",
+            "ends": "2020-07-06T18:59:00+09:00"
+        }
+    ],
+    "updates": [
+        {
+            "name": {
+                "en": "Pride of the Ascendent - Earth-advantage",
+                "jp": "天上征伐戦 - 土有利"
+            },
+            "release-date": "2020-06-09T19:00:00+09:00"
+        },
+        {
+            "name": {
+                "en": "2020-06 Character Rebalance",
+                "jp": "2020-06 バランス調整"
+            },
+            "release-date": "2020-06-09T19:00:00+09:00"
+        }
+    ],
+    "scheduled": [
+        {
+            "june": {
+                "period": "middle",
+                "events": {
+                    "en": [
+                        "New Class IV Job: Monk",
+                        "Treasure Trade Shop redesign"
+                    ],
+                    "jp": [
+                        "新クラスⅣジョブ「モンク」実装",
+                        "「ショップ」の「トレジャー交換」ページ改修"
+                    ]
+                }
+            },
+            "july": {
+                "period": "end",
+                "events": {
+                    "en": [
+                        "Main Story Quest update - 8 chapters"
+                    ],
+                    "jp": [
+                        "メインクエスト追加 - 8章"
+                    ]
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Overview
**Issue:** https://github.com/jedmund/siero-bot/issues/5

This adds a basic `$schedule` command to Siero. Users can see the upcoming schedule, the current event, and the next event. Campaigns and content additions are not supported yet, but will be added in the future.

![image](https://user-images.githubusercontent.com/383021/83513468-b0fa7b80-a486-11ea-9244-8573771719c0.png)
![image](https://user-images.githubusercontent.com/383021/83513440-a50eb980-a486-11ea-933c-bfa6f26df6da.png)


## Testing

- [x] `$schedule` -> Should show the schedule
- [x] `$schedule show` -> Should show the schedule
- [x] `$schedule now` -> Should show the current event
- [x] `$schedule current` -> Should show the current event
- [x] `$schedule next` -> Should show the next event
- [x] `$schedule help` -> Should show the command help
