### PR TITLE
ISSUE-45: Add matching for lowercase queries

### DIFF
--- a/src/helpers/common.js
+++ b/src/helpers/common.js
@@ -4,6 +4,10 @@ const { pgpErrors } = require('../services/connection.js')
 const common = require('./common.js')
 
 module.exports = {
+    capitalize: function(string) {
+        return string.charAt(0).toUpperCase() + string.slice(1)
+    },
+
     mapRarity: function(rarity) {
         var rarityString = ""
 

--- a/src/helpers/common.js
+++ b/src/helpers/common.js
@@ -7,30 +7,28 @@ module.exports = {
     capitalize: function(string, allWords = false) {
         const blacklist = ['of', 'the', 'for', 'and']
         if (allWords) {
-            const split = string.split(' ').map((item) => {
+            return string.split(' ').map((item) => {
                 if (!blacklist.includes(item)) { 
                     return item.charAt(0).toUpperCase() + item.slice(1) 
                 } else {
                     return item
                 }
-            })
-
-            return split.join(' ')
+            }).join(' ')
         } else {
             return string.charAt(0).toUpperCase() + string.slice(1)
         }
     },
 
-    parse: function(request, parts = 2, properties = null) {
-        let splitRequest = request.split(' ')
+    parse: function(request, properties = null) {
+        let rq = request
 
         if (properties) {
-            splitRequest = [splitRequest, [properties.gala, properties.season]].reduce((a, c) => a.filter(i => !c.includes(i)))
+            const splitRequest = request.split(' ')
+            const reducedRequest = [splitRequest, [properties.gala, properties.season]].reduce((a, c) => a.filter(i => !c.includes(i)))
+            rq = reducedRequest.join(' ')
         }
 
-        const rejoinedRequest = splitRequest.splice(parts).join(' ')
-
-        let target = this.capitalize(rejoinedRequest, true)
+        let target = this.capitalize(rq, true)
 
         // match unwrapped 'grand'
         // ex: $g until io grand lf

--- a/src/subcommands/gacha/rateup.ts
+++ b/src/subcommands/gacha/rateup.ts
@@ -67,7 +67,7 @@ class Rateup {
             const parts = item.split(' ')
 
             const rate = parseFloat(parts.pop()!)
-            const name = parts.join(' ').replace(quoteRe, '')
+            const name = common.capitalize(parts.join(' ').replace(quoteRe, ''), true)
 
             this.rates.push(
                 {

--- a/src/subcommands/gacha/until.ts
+++ b/src/subcommands/gacha/until.ts
@@ -43,7 +43,7 @@ class Until {
         this.rateups = rateups
 
         this.properties = this.parseProperties(message.content)
-        this.target = this.parseTarget(message.content)
+        this.target = common.parse(message.content, 2, this.properties)
     }
 
     public async execute() {
@@ -111,31 +111,6 @@ class Until {
             gala: gala,
             season: season
         }
-    }
-
-    private parseTarget(request: string) {
-        const splitRequest = request.split(' ')
-        const reducedRequest = [splitRequest, [this.properties.gala, this.properties.season]].reduce((a, c) => a.filter(i => !c.includes(i)))
-        const rejoinedRequest = reducedRequest.splice(2).join(' ')
-        let target = common.capitalize(rejoinedRequest)
-
-        // match unwrapped 'grand'
-        // ex: $g until io grand lf
-        const re1: RegExp = /(?!\()grand(?!\))/ig
-        if (target.match(re1)) {
-            const match = target.match(re1)
-            target = target.replace(match, '(Grand)')
-        }
-
-        // match lowercase wrapped 'grand'
-        // ex: $g until io (grand) lf
-        const re2: RegExp = /\(grand\)/g
-        if (target.match(re2)) {
-            const match = target.match(re2)
-            target = target.replace(match, '(Grand)')
-        }
-
-        return target
     }
 
     // Action methods

--- a/src/subcommands/gacha/until.ts
+++ b/src/subcommands/gacha/until.ts
@@ -43,7 +43,9 @@ class Until {
         this.rateups = rateups
 
         this.properties = this.parseProperties(message.content)
-        this.target = common.parse(message.content, 2, this.properties)
+
+        const target = message.content.split(' ').splice(2).join(' ')
+        this.target = common.parse(target, this.properties)
     }
 
     public async execute() {

--- a/src/subcommands/gacha/until.ts
+++ b/src/subcommands/gacha/until.ts
@@ -115,9 +115,27 @@ class Until {
 
     private parseTarget(request: string) {
         const splitRequest = request.split(' ')
-        const target = [splitRequest, [this.properties.gala, this.properties.season]].reduce((a, c) => a.filter(i => !c.includes(i)))
+        const reducedRequest = [splitRequest, [this.properties.gala, this.properties.season]].reduce((a, c) => a.filter(i => !c.includes(i)))
+        const rejoinedRequest = reducedRequest.splice(2).join(' ')
+        let target = common.capitalize(rejoinedRequest)
 
-        return target.splice(2).join(' ')
+        // match unwrapped 'grand'
+        // ex: $g until io grand lf
+        const re1: RegExp = /(?!\()grand(?!\))/ig
+        if (target.match(re1)) {
+            const match = target.match(re1)
+            target = target.replace(match, '(Grand)')
+        }
+
+        // match lowercase wrapped 'grand'
+        // ex: $g until io (grand) lf
+        const re2: RegExp = /\(grand\)/g
+        if (target.match(re2)) {
+            const match = target.match(re2)
+            target = target.replace(match, '(Grand)')
+        }
+
+        return target
     }
 
     // Action methods

--- a/src/subcommands/spark/target.ts
+++ b/src/subcommands/spark/target.ts
@@ -26,6 +26,7 @@ class Target {
     public constructor(message: Message) {
         this.userId = message.author.id
         this.message = message
+
         this.parseRequest(message.content)
     }
 
@@ -47,7 +48,7 @@ class Target {
             splitRequest.splice(splitRequest.indexOf('unreleased', 1)).join(' ')
         }
 
-        this.targetName = splitRequest.join(' ')
+        this.targetName = common.parse(request, 3)
     }
 
     private switchOperation() {

--- a/src/subcommands/spark/target.ts
+++ b/src/subcommands/spark/target.ts
@@ -48,7 +48,7 @@ class Target {
             splitRequest.splice(splitRequest.indexOf('unreleased', 1)).join(' ')
         }
 
-        this.targetName = common.parse(request, 3)
+        this.targetName = common.parse(splitRequest.join(' '))
     }
 
     private switchOperation() {


### PR DESCRIPTION
## Overview
**Issue:** https://github.com/jedmund/siero-bot/issues/45

Queries that involve gacha items are case-sensitive. This isn't intuitive for most people, so this PR adds code to auto-capitalize strings and fix (Grand) tags.

## Testing
All of these commands should work as if they were capitalized properly:
- [x] `$gacha until io grand`
- [x] `$gacha until io (grand)`
- [x] `$spark target set vortex of the void`
- [x] `$gacha rateup set ixaba 0.3, blue sphere 0.3`
