### PR TITLE
Small updates and fixes to $schedule

### DIFF
--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -176,14 +176,16 @@ class ScheduleCommand extends Command {
 
         for (let i in events) {
             let event: Event = events[i]
-            
-            const isCurrentEvent: boolean = (dayjs(event.starts).isBefore(dayjs()) && dayjs(event.ends).isAfter(dayjs()))
-            const startsString: string = `<Starts in ${dayjs().to(event.starts, true)}>\n${dayjs(event.starts).format('LLLL')} JST`
-            const endsString: string = `<Ends in ${dayjs().to(event.ends, true)}>\n${dayjs(event.ends).format('LLLL')} JST`
-            const dateString: string = (isCurrentEvent) ? endsString : startsString
 
-            let duration: string = `\`\`\`html\n${dateString}\n\`\`\``
-            embed.addField(event.name.en, duration)
+            if (dayjs(event.ends).isAfter(dayjs())) {
+                const isCurrentEvent: boolean = (dayjs(event.starts).isBefore(dayjs()) && dayjs(event.ends).isAfter(dayjs()))
+                const startsString: string = `<Starts in ${dayjs().to(event.starts, true)}>\n${dayjs(event.starts).format('LLLL')} JST`
+                const endsString: string = `<Ends in ${dayjs().to(event.ends, true)}>\n${dayjs(event.ends).format('LLLL')} JST`
+                const dateString: string = (isCurrentEvent) ? endsString : startsString
+
+                let duration: string = `\`\`\`html\n${dateString}\n\`\`\``
+                embed.addField(event.name.en, duration)
+            }
         }
 
         return embed

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -21,6 +21,7 @@ interface Event {
     starts: string
     ends: string
     advantage: string | null
+    link: string | null
 }
 
 interface Month {
@@ -238,6 +239,10 @@ class ScheduleCommand extends Command {
             if (key === 'advantage' && event[key]) {
                 const advantage: string = event[key]!
                 embed.addField(readableKey, this.capitalize(advantage))
+            }
+            
+            if (key === 'link') {
+                embed.addField('Wiki', event[key])
             }
         }
 

--- a/src/resources/schedule.json
+++ b/src/resources/schedule.json
@@ -2,6 +2,18 @@
     "events": [
         {
             "name": {
+                "en": "Cinderella Fantasy: To the Skies Once More",
+                "jp": "シンデレラファンタジー ふたたび始まる空の旅"
+            },
+            "banner": "https://gbf.wiki/images/6/6c/The_Doss%21_End_of_the_Line_Farewell_Tour_top.jpg",
+            "link": "https://gbf.wiki/Cinderella_Fantasy:_To_the_Skies_Once_More",
+            "type": "collab",
+            "advantage": "light",
+            "starts": "2020-05-15T17:00:00+09:00",
+            "ends": "2020-05-27T20:59:00+09:00"
+        },
+        {
+            "name": {
                 "en": "The Doss! End of the Line Farewell Tour",
                 "jp": "The End of THE DOSS"
             },

--- a/src/resources/schedule.json
+++ b/src/resources/schedule.json
@@ -6,6 +6,7 @@
                 "jp": "The End of THE DOSS"
             },
             "banner": "https://gbf.wiki/images/6/6c/The_Doss%21_End_of_the_Line_Farewell_Tour_top.jpg",
+            "link": "https://gbf.wiki/The_Doss!_End_of_the_Line_Farewell_Tour",
             "type": "scenario",
             "advantage": "fire",
             "starts": "2020-05-29T19:00:00+09:00",
@@ -17,6 +18,7 @@
                 "jp": "四象降臨"
             },
             "banner": "https://gbf.wiki/images/d/dd/Riseofthebeasts_top.png",
+            "link": "https://gbf.wiki/Rise_of_the_Beasts",
             "type": "farming",
             "starts": "2020-06-07T17:00:00+09:00",
             "ends": "2020-06-14T20:59:00+09:00"
@@ -27,6 +29,7 @@
                 "jp": "ゼノイフリート撃滅戦"
             },
             "banner": "https://gbf.wiki/images/7/7c/Xeno_Ifrit_Clash_top.png",
+            "link": "https://gbf.wiki/Xeno_Ifrit_Clash",
             "type": "farming",
             "advantage": "water",
             "starts": "2020-06-13T17:00:00+09:00",
@@ -38,6 +41,7 @@
                 "jp": "決戦！星の古戦場 - 火有利"
             },
             "banner": "https://gbf.wiki/images/0/09/UniteAndFight.png",
+            "link": "https://gbf.wiki/Unite_and_Fight",
             "type": "guild-wars",
             "advantage": "fire",
             "starts": "2020-06-20T19:00:00+09:00",
@@ -49,6 +53,7 @@
                 "jp": "プレミウムフライデークエスト"
             },
             "banner": "https://gbf.wiki/images/8/81/Premium_Friday_top.png",
+            "link": "https://gbf.wiki/Premium_Friday",
             "type": "friday",
             "starts": "2020-06-26T15:00:00+09:00",
             "ends": "2020-06-28T23:59:00+09:00"


### PR DESCRIPTION
## Overview
**Issues:** https://github.com/jedmund/siero-bot/issues/89, https://github.com/jedmund/siero-bot/issues/90

This adds wiki links to `$schedule now` and `$schedule next` as well as prevents `$schedule` from showing stale events.

## Testing

- [ ] `$schedule now` -> Should show a `Wiki` field with a link
- [ ] `$schedule next` -> Should show a `Wiki` field with a link
- [ ] `$schedule` - > Should not show events that have ended (as of this PR, Cinderella Fantasy should not appear)

Resolves #89, resolves #90