### PR TITLE
Add support for custom prefixes

### DIFF
--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -6,7 +6,7 @@ const dayjs = require('dayjs')
 class HelpCommand extends Command {
     constructor() {
         super('help', {
-            aliases: ['help', 'h'],
+            aliases: ['help'],
             args: []
         })
     }
@@ -20,16 +20,24 @@ class HelpCommand extends Command {
             color: 0xdc322f
         })
 
+        const discord = 'Come help with development or get support in Siero\'s Discord:\nhttps://discord.gg/37u2uz7'
+
         if (message.channel.type !== 'dm') {
             await common.fetchPrefix(message.guild.id)
                 .then((prefix) => {
                     const commands = this.helpContent(prefix)
                     embed.addField('Commands', commands)
+                    embed.addField('Even more help', `You can get help on any of the above commands by typing \`help\` after the command, like so: 
+\`\`\`${prefix}gacha help\`\`\``)
+                    embed.addField('Support Discord', discord)
                     message.channel.send(embed)
                 })
         } else {
             const commands = this.helpContent()
             embed.addField('Commands', commands)
+            embed.addField('Even more help', `You can get help on any of the above commands by typing \`help\` after the command, like so: 
+\`\`\`$gacha help\`\`\``)
+            embed.addField('Support Discord', discord)
             message.channel.send(embed)
         }
     }

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -1,5 +1,6 @@
 const { Command } = require('discord-akairo')
 const { MessageEmbed } = require('discord.js')
+const common = require('../helpers/common.js')
 const dayjs = require('dayjs')
 
 class HelpCommand extends Command {
@@ -10,29 +11,44 @@ class HelpCommand extends Command {
         })
     }
 
-    exec(message, args) {        
+    async exec(message, args) {        
         console.log(`(${dayjs().format('YYYY-MM-DD HH:mm:ss')}) [${message.author.id}] ${message.content}`)
         
-        var embed = new MessageEmbed()
-        embed.setTitle("Help")
-        embed.setDescription("Welcome! Here are all the things I can do!")
-        embed.setColor(0xdc322f)
-        embed.addField("Commands", `\`\`\`html\n
-<$gacha $g>
-Roll the virtual gacha\n
-<$profile $p>
-Save useful information in your profile or see someone else's\n
-<$spark $s> 
-Log your progress while saving a spark\n
-<$schedule $sc> 
-Show the upcoming schedule in Granblue Fantasy\n
-<$sticker $ss>
-Use a Granblue sticker in Discord\`\`\``)
-        embed.addField("Even more help", `You can get help on any of the above commands by typing \`help\` after the command, like so: 
-\`\`\`$gacha help\`\`\``)
-        embed.addField("Support Discord", 'Come help with development or get support in Siero\'s Discord:\nhttps://discord.gg/37u2uz7')
+        let embed = new MessageEmbed({
+            title: 'Help',
+            description: 'Welcome! How can I help you?',
+            color: 0xdc322f
+        })
 
-        message.channel.send(embed)
+        if (message.channel.type !== 'dm') {
+            await common.fetchPrefix(message.guild.id)
+                .then((prefix) => {
+                    const commands = this.helpContent(prefix)
+                    embed.addField('Commands', commands)
+                    message.channel.send(embed)
+                })
+        } else {
+            const commands = this.helpContent()
+            embed.addField('Commands', commands)
+            message.channel.send(embed)
+        }
+    }
+
+    helpContent(prefix = '$') {
+        return [
+            '```html',
+            `<${prefix}gacha> or <${prefix}g>`,
+            'Simulate gacha pulls\n',
+            `<${prefix}profile> or <${prefix}p>`,
+            'Save a profile with your gaming usernames, or see someone else\'s\n',
+            `<${prefix}schedule> or <${prefix}sc>`,
+            'Show the upcoming schedule for Granblue Fantasy\n',
+            `<${prefix}spark> or <${prefix}s>`,
+            'Log your spark progress, or see someone else\'s\n',
+            `<${prefix}sticker> or <${prefix}ss>`,
+            'Use a Granblue Fantasy sticker in Discord',
+            '```'
+        ].join('\n')
     }
 }
 

--- a/src/commands/prefix.ts
+++ b/src/commands/prefix.ts
@@ -1,0 +1,131 @@
+import { Client } from '../services/connection.js'
+import { Message, MessageEmbed } from 'discord.js'
+import { Command } from 'discord-akairo'
+
+const common = require('../helpers/common.js')
+const dayjs = require('dayjs')
+
+interface PrefixArgs {
+    operation: string
+    prefix: string | null
+}
+
+class PrefixCommand extends Command {
+    args?: PrefixArgs
+    message?: Message
+    commandType: string = 'prefix'
+
+    public constructor() {
+        super('prefix', {
+            aliases: ['prefix'],
+            args: [
+                { id: 'operation' },
+                { id: 'prefix' }
+            ],
+            channel: 'guild'
+        })
+    }
+
+    public exec(message: Message, args: PrefixArgs) {
+        console.log(`(${dayjs().format('YYYY-MM-DD HH:mm:ss')}) [${message.author.id}] ${message.content}`)
+
+        common.storeArgs(this, args)
+        common.storeMessage(this, message)
+
+        this.switchOperation()
+    }
+
+    private switchOperation() {
+        const operation = this.args?.operation
+
+        switch (operation) {
+            case 'set':
+                this.set()
+                break
+
+            case 'help':
+                this.help()
+                break
+
+            default:
+                this.help()
+                break
+        }
+    }
+
+    // Command methods
+    private set() {
+        const regex: RegExp = /[!$%^&*~=:;?]*/
+
+        const message = this.message!
+        const guild = message.guild!
+        const owner = guild.owner!
+        const args = this.args!
+
+        if (message.author.id === owner.id) {
+            let matches: RegExpMatchArray | null | undefined = args.prefix?.match(regex)
+
+            if (matches && matches[0]) {
+                this.save(guild.id, matches[0])
+            } else {
+                this.invalidPrefix(args.prefix!)
+            }
+        } else {
+            message.reply(`only the owner of **${guild.name}** can set the server's command prefix.`)
+        }
+    }
+
+    private help() {
+        const embed = new MessageEmbed({
+            title: 'Command prefix',
+            description: 'Welcome! You can set your server\'s command prefix with this command, but only if you\'re the server owner!',
+            color: 0xdc322f,
+            fields: [
+                {
+                    name: 'Command syntax',
+                    value: '```set <prefix>```'
+                },
+                {
+                    name: 'Supported characters',
+                    value: '```! $ % ^ & * ~ = : ; ?```'
+                }
+            ]
+        })
+    
+        this.message?.channel.send(embed)
+    }
+
+    // Database methods
+    private save(guildId: string, prefix: string) {
+        const sql = [
+            'INSERT INTO guilds (id, prefix)',
+            'VALUES ($1, $2)',
+            'ON CONFLICT (id)',
+            'DO UPDATE SET prefix = $2',
+            'WHERE guilds.id = $1'
+        ].join(' ')
+
+        Client.none(sql, [guildId, prefix])
+            .then(() => {
+                const message = this.message!
+                const guild = message.guild!
+
+                message.channel.send(`The command prefix for **${guild.name}** has been changed to **${prefix}**.`)
+            })
+    }
+
+    // Error methods
+    private invalidPrefix(prefix: string) {
+        const text = 'The character you supplied is not supported.'
+        const error = `Unsupported prefix: ${prefix}`
+        const section = {
+            title: 'Supported characters',
+            content: '```! $ % ^ & * ~ = : ; ?```'
+        }
+
+        common.reportError(this.message, this.message?.author.id, this.commandType, error, text, false, section)
+
+    }
+}
+
+module.exports = PrefixCommand

--- a/src/helpers/common.js
+++ b/src/helpers/common.js
@@ -1,3 +1,4 @@
+const { Client } = require('../services/connection.js')
 const { DiscordAPIError, MessageEmbed } = require('discord.js')
 const { pgpErrors } = require('../services/connection.js')
 
@@ -120,6 +121,23 @@ module.exports = {
         }
 
         return spacedString
+    },
+
+    // Database methods
+    fetchPrefix: async function(guildId) {
+        const sql = 'SELECT prefix FROM guilds WHERE id = $1 LIMIT 1'
+
+        return await Client.oneOrNone(sql, guildId)
+            .then((result) => {
+                if (result.prefix) {
+                    return result.prefix
+                } else {
+                    return '$'
+                }
+            })
+            .catch((error) => {
+                console.error(`There was an error fetching a prefix for ${guildId}`)
+            })
     },
 
     // Property persistance methods

--- a/src/resources/dbupdate_v3.0.pgsql
+++ b/src/resources/dbupdate_v3.0.pgsql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS guilds (
+    id text DEFAULT PRIMARY KEY,
+    prefix text
+);

--- a/src/resources/dbupdate_v3.0.pgsql
+++ b/src/resources/dbupdate_v3.0.pgsql
@@ -1,4 +1,4 @@
 CREATE TABLE IF NOT EXISTS guilds (
-    id text DEFAULT PRIMARY KEY,
+    id text PRIMARY KEY,
     prefix text
 );

--- a/src/resources/startup.pgsql
+++ b/src/resources/startup.pgsql
@@ -54,9 +54,14 @@ CREATE TABLE IF NOT EXISTS profiles (
     xbox TEXT
 );
 
-CREATE TABLE rateups (
+CREATE TABLE IF NOT EXISTS rateups (
     id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
     gacha_id uuid,
     user_id text,
     rate numeric
+);
+
+CREATE TABLE IF NOT EXISTS guilds (
+    id text DEFAULT PRIMARY KEY,
+    prefix text
 );

--- a/src/resources/startup.pgsql
+++ b/src/resources/startup.pgsql
@@ -62,6 +62,6 @@ CREATE TABLE IF NOT EXISTS rateups (
 );
 
 CREATE TABLE IF NOT EXISTS guilds (
-    id text DEFAULT PRIMARY KEY,
+    id text PRIMARY KEY,
     prefix text
 );

--- a/src/subcommands/gacha/rateup.ts
+++ b/src/subcommands/gacha/rateup.ts
@@ -21,6 +21,7 @@ interface RateSet {
 class Rateup {
     userId: string
     siero: User | null
+    prefix: string = '$'
 
     operation: string | null = null
     rates: Rate[] = []
@@ -37,8 +38,12 @@ class Rateup {
         this.parseRequest(message.content)
     }
 
-    public execute() {
-        return this.switchOperation()
+    public async execute() {
+        await common.fetchPrefix(this.message.guild!.id)
+            .then((prefix: string) => {
+                this.prefix = prefix
+                return this.switchOperation()
+            })
     }
 
     private parseRequest(request: string) {
@@ -287,7 +292,7 @@ class Rateup {
             color: 0xb58900,
             footer: {
                 iconURL: user.displayAvatarURL(),
-                text: `Copy with $gacha rateup copy @${user.username}`
+                text: `Copy with ${this.prefix}gacha rateup copy @${user.username}`
             }
         })
 


### PR DESCRIPTION
## Overview
Resolves #104 

This allows server owners to set a custom command prefix for their server with `$prefix set <prefix>`.

## Testing
First, create a server where you are the owner, then run the commands below:
- [x] `$prefix set %` -> Should successfully set your prefix to `%`
- [x] `$prefix set a` -> Should return an error, as `a` is not a valid prefix.
- [x] `$help` -> Should show the help card with custom prefixes
- [x] `$gacha rateup show @Siero` -> Should show the rateup card, with custom prefixes in the command in the footer
