### PR TITLE
Add support for various event types in $schedule

### DIFF
--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -28,12 +28,14 @@ type NumberObject = { [key: string]: number }
 type NullableNumber = number | null
 
 interface Event {
-    readonly [index: string]: string | LocalizedString | null
+    readonly [index: string]: string | LocalizedString | string[] | null
     name: LocalizedString
     type: string
     starts: string
     ends: string
     advantage: string | null
+    info: string[]
+    banner: string | null
     link: string | null
 }
 
@@ -46,18 +48,9 @@ interface Month {
     }
 }
 
-interface Magfest {
-    name: string,
-    info: string[],
-    wiki: string,
-    banner: string,
-    starts: string,
-    ends: string
-}
-
 interface Schedule {
     maintenance: Duration | null
-    magfest: Magfest | null
+    magfest: Event | null
     events: Event[]
     scheduled: Month[]
 }
@@ -78,14 +71,7 @@ class ScheduleCommand extends Command {
         maintenance: null,
         events: [],
         scheduled: [],
-        magfest: {
-            name: '',
-            info: [],
-            wiki: '',
-            banner: '',
-            starts: '',
-            ends: ''
-        }
+        magfest: null
     }
 
     public constructor() {
@@ -345,7 +331,10 @@ class ScheduleCommand extends Command {
             const magfest = this.schedule.magfest
 
             embed.setTitle(magfest.name)
-            embed.setImage(magfest.banner)
+
+            if (magfest.banner) {
+                embed.setImage(magfest.banner)
+            }
 
             if (isMagfest) {
                 embed.setAuthor(`Ends in ${this.buildDiffString(magfest.ends)}`)
@@ -398,8 +387,8 @@ class ScheduleCommand extends Command {
             } else if (isMagfest) {
                 const difference = this.buildDiffString(this.schedule.magfest.ends)
 
-                name = this.schedule.magfest.name
-                image = this.schedule.magfest.banner
+                name = this.schedule.magfest.name.en
+                image = (this.schedule.magfest.banner) ? this.schedule.magfest.banner : ''
                 description = `The ${this.schedule.magfest.name} is underway for the next **${difference}**.\n\nFor more info, use \`$schedule magfest\`.\n\n**Event Schedule**\u00A0`
             }
         }

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -49,6 +49,7 @@ interface Month {
 interface Magfest {
     name: string,
     info: string[],
+    wiki: string,
     banner: string,
     starts: string,
     ends: string
@@ -80,6 +81,7 @@ class ScheduleCommand extends Command {
         magfest: {
             name: '',
             info: [],
+            wiki: '',
             banner: '',
             starts: '',
             ends: ''
@@ -126,6 +128,10 @@ class ScheduleCommand extends Command {
 
             case 'now':
                 this.current()
+                break
+
+            case 'magfest':
+                this.magfest()
                 break
 
             case 'help':
@@ -181,6 +187,18 @@ class ScheduleCommand extends Command {
             } else {
                 this.message!.channel.send('There is no event running right now. Use `$schedule next` to find out what event is running next.')
             }
+        }
+    }
+
+    private magfest(): void {
+        const isMagfest = this.schedule.magfest && dayjs().isBetween(dayjs(this.schedule.magfest.starts), dayjs(this.schedule.magfest.ends))
+        const upcomingMagfest = this.schedule.magfest && dayjs(this.schedule.magfest.starts).isBetween(dayjs(), dayjs().add(48, 'hours'))
+
+        if (isMagfest || upcomingMagfest) {
+            const embed: MessageEmbed = this.renderMagfest()
+            this.message!.channel.send(embed)
+        } else {
+            this.message?.channel.send('There is no upcoming magfest right now.')
         }
     }
 
@@ -311,6 +329,32 @@ class ScheduleCommand extends Command {
             if (key === 'link') {
                 embed.addField('Wiki', event[key])
             }
+        }
+
+        return embed
+    }
+
+    private renderMagfest(): MessageEmbed {
+        let embed = new MessageEmbed({
+            color: 0xdc322f
+        })
+
+        const isMagfest = this.schedule.magfest && dayjs().isBetween(dayjs(this.schedule.magfest.starts), dayjs(this.schedule.magfest.ends))
+
+        if (this.schedule.magfest) {
+            const magfest = this.schedule.magfest
+
+            embed.setTitle(magfest.name)
+            embed.setImage(magfest.banner)
+
+            if (isMagfest) {
+                embed.setAuthor(`Ends in ${this.buildDiffString(magfest.ends)}`)
+            } else {
+                embed.setAuthor(`Starts in ${this.buildDiffString(magfest.starts)}`)
+            }
+
+            embed.addField('Wiki', magfest.wiki)
+            embed.addField('Content', `\`\`\`${magfest.info.join('\n')}\`\`\``)
         }
 
         return embed

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -378,12 +378,12 @@ class ScheduleCommand extends Command {
                 const duration = this.buildString(null, parts.days, parts.hours)
                 
                 name = 'Upcoming Maintenance'
-                description = `Granblue Fantasy will be undergoing maintenance in **${difference}**.\nMaintenance will last for **${duration}**.\n\n**Upcoming Events**\u00A0`
+                description = `Granblue Fantasy will be undergoing maintenance in **${difference}**.\nMaintenance will last for **${duration}**.\n\n**Event Schedule**\u00A0`
             } else if (isMaintenance) {
                 const difference = this.buildDiffString(this.schedule.maintenance.ends)
 
                 name = 'Maintenance'
-                description = `Granblue Fantasy is currently undergoing maintenance.\nIt will end in **${difference}**.\n\n**Upcoming Events**\u00A0`
+                description = `Granblue Fantasy is currently undergoing maintenance.\nIt will end in **${difference}**.\n\n**Event Schedule**\u00A0`
             }
         }
 
@@ -394,13 +394,13 @@ class ScheduleCommand extends Command {
                 const duration = this.buildString(null, parts.days, parts.hours)
                 
                 name = `${this.schedule.magfest.name} coming soon!`
-                description = `The ${this.schedule.magfest.name} starts in **${difference}**! It will last for **${duration}**.\n\nFor more info, use \`$schedule magfest\`.\n\n**Upcoming Events**\u00A0`
+                description = `The ${this.schedule.magfest.name} starts in **${difference}**! It will last for **${duration}**.\n\nFor more info, use \`$schedule magfest\`.\n\n**Event Schedule**\u00A0`
             } else if (isMagfest) {
                 const difference = this.buildDiffString(this.schedule.magfest.ends)
 
                 name = this.schedule.magfest.name
                 image = this.schedule.magfest.banner
-                description = `The ${this.schedule.magfest.name} is underway for the next **${difference}**.\n\nFor more info, use \`$schedule magfest\`.\n\n**Upcoming Events**\u00A0`
+                description = `The ${this.schedule.magfest.name} is underway for the next **${difference}**.\n\nFor more info, use \`$schedule magfest\`.\n\n**Event Schedule**\u00A0`
             }
         }
 

--- a/src/resources/schedule.json
+++ b/src/resources/schedule.json
@@ -5,7 +5,7 @@
     },
     "magfest": {
         "name": {
-            "en": "Granblue Big Summer Surprise",
+            "en": "",
             "jp": ""
         },
         "info": [
@@ -23,10 +23,10 @@
             "2x Boost to Shop Skills",
             "Arcarum Badge Bonus Bash"
         ],
-        "wiki": "https://gbf.wiki/Granblue_Big_Summer_Surprise/2019",
-        "banner": "https://gbf.wiki/images/6/6a/News_2200campaign_1.png",
-        "starts": "2020-01-03T08:00:00+09:00",
-        "ends": "2020-01-16T08:00:00+09:00"
+        "wiki": "",
+        "banner": "",
+        "starts": "2020-01-01T08:00:00+09:00",
+        "ends": "2020-01-01T08:00:00+09:00"
     },
     "streams": [
         {

--- a/src/resources/schedule.json
+++ b/src/resources/schedule.json
@@ -1,11 +1,32 @@
 {
     "maintenance": {
-        "starts": "2020-06-09T01:00:00+09:00",
-        "ends": "2020-06-09T08:00:00+09:00"
+        "starts": "2020-01-01T01:00:00+09:00",
+        "ends": "2020-01-01T21:00:00+09:00"
     },
     "magfest": {
-        "starts": "",
-        "ends": ""
+        "name": {
+            "en": "Granblue Big Summer Surprise",
+            "jp": ""
+        },
+        "info": [
+            "Free Daily 10-Part Draw",
+            "Free Daily Premium Draw",
+            "Daily 200 Crystal Bonus",
+            "Campaign-Exclusive Quest",
+            "1.5x More RP/EXP",
+            "Half AP/EP Event",
+            "Half AP for Free Quests",
+            "Half AP for Side Story Quests",
+            "Half Off Treasure Trade Cost",
+            "Half Treasure Cost",
+            "More Renown and Prestige Pendants",
+            "2x Boost to Shop Skills",
+            "Arcarum Badge Bonus Bash"
+        ],
+        "wiki": "https://gbf.wiki/Granblue_Big_Summer_Surprise/2019",
+        "banner": "https://gbf.wiki/images/6/6a/News_2200campaign_1.png",
+        "starts": "2020-01-03T08:00:00+09:00",
+        "ends": "2020-01-16T08:00:00+09:00"
     },
     "streams": [
         {
@@ -13,8 +34,8 @@
                 "en": "Hot Hot Hot! Granblue Summer Live Stream",
                 "jp": "熱いぜ！グラブルの夏！SP"
             },
-            "airtime": "2020-08-08T18:00:00+09:00",
-            "endtime": "2020-08-08T21:00:00+09:00",
+            "starts": "2020-08-08T18:00:00+09:00",
+            "ends": "2020-08-08T21:00:00+09:00",
             "link": ""
         }
     ],

--- a/src/resources/schedule.json
+++ b/src/resources/schedule.json
@@ -3,6 +3,21 @@
         "starts": "2020-06-09T01:00:00+09:00",
         "ends": "2020-06-09T08:00:00+09:00"
     },
+    "magfest": {
+        "starts": "",
+        "ends": ""
+    },
+    "streams": [
+        {
+            "name": {
+                "en": "Hot Hot Hot! Granblue Summer Live Stream",
+                "jp": "熱いぜ！グラブルの夏！SP"
+            },
+            "airtime": "2020-08-08T18:00:00+09:00",
+            "endtime": "2020-08-08T21:00:00+09:00",
+            "link": ""
+        }
+    ],
     "events": [
         {
             "name": {
@@ -156,6 +171,27 @@
                 "jp": "2020-06 バランス調整"
             },
             "release-date": "2020-06-09T19:00:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Main Story Quest 133-140",
+                "jp": "メインクエスト133-140章"
+            },
+            "release-date": "2020-07-20T19:00:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Six Dragons HL Raids",
+                "jp": "新マルチバトル「六竜ＨＬ」追加"
+            },
+            "release-date": "2020-07-27T19:00:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Damascus Brick added to Shop",
+                "jp": "ダマスカス鋼の在庫追加"
+            },
+            "release-date": "2020-07-29T19:00:00+09:00"
         }
     ],
     "scheduled": [
@@ -175,13 +211,61 @@
         },
         {
             "month": "july",
-            "period": "end",
+            "period": "unspecified",
             "events": {
                 "en": [
-                    "Main Story Quest update - 8 chapters"
+                    "New Sidestory: By Any Other Name",
+                    "4★ Uncap for (SSR) Christina",
+                    "4 Additional EX Poses",
+                    "Update to Forge Class Champion Weapons",
+                    "Update to Awakening",
+                    "Update to reducing weapons and summons",
+                    "Update to Omens in Battle System v2"
                 ],
                 "jp": [
-                    "メインクエスト追加 - 8章"
+                    "サイドストーリーに「この想いを、何に喩えようか」追加",
+                    "SSRクリスティーナ 最終上限解放",
+                    "「EX POSE」追加",
+                    "「英雄武器の作成」ページ改修",
+                    "「覚醒Lv」アップデート",
+                    "「エレメント化」アップデート",
+                    "「バトルシステム Ver.2」における「予兆演出」のアップデート"
+                ]
+            }
+        },
+        {
+            "month": "august",
+            "period": "unspecified",
+            "events": {
+                "en": [
+                    "Battle System v2 Ability Rebalance"
+                ],
+                "jp": [
+                    "「バトルシステム Ver.2」における「一部キャラクターのアビリティ対応について」"
+                ]
+            }
+        },
+        {
+            "month": "october",
+            "period": "middle",
+            "events": {
+                "en": [
+                    "Crew Valor Badge Event"
+                ],
+                "jp": [
+                    "勲章を獲得できる新イベント"
+                ]
+            }
+        },
+        {
+            "month": "november",
+            "period": "middle",
+            "events": {
+                "en": [
+                    "Unite and Fight: Dark-advantage"
+                ],
+                "jp": [
+                    "決戦！星の古戦場 - 闇有利"
                 ]
             }
         }


### PR DESCRIPTION
## Overview
Maintenance, Magfest, and livestreams will be shown in `$schedule` if they are currently happening, or will happen within a time threshold.

### Thresholds
Maintenance: 2 days
Magfest: 2 days
Livestream: 7 days

This also adds `$schedule magfest` to show what promotions are live during that magfest.

## Testing

Modify `schedule.json` and check `$schedule`:
- [x] A maintenance event that will happen soon
- [x] A currently occurring maintenance event
- [x] A magfest event that will happen soon
- [x] A currently occurring magfest event
- [x] A livestream that will happen soon
- [x] A currently airing livestream

You should also check `$schedule magfest` for an upcoming or currently occuring Magfest.