### PR TITLE
Add $time command

### DIFF
--- a/src/commands/time.ts
+++ b/src/commands/time.ts
@@ -1,0 +1,24 @@
+import { Message } from 'discord.js'
+import { SieroCommand } from '../helpers/SieroCommand'
+
+import dayjsPluginUTC from 'dayjs-plugin-utc'
+
+const dayjs = require('dayjs')
+dayjs.extend(dayjsPluginUTC)
+
+class TimeCommand extends SieroCommand {
+    public constructor() {
+        super('time', {
+            aliases: ['time']
+        })
+    }
+
+    public exec(message: Message) {
+        this.log(message)
+
+        const japanTime = dayjs().utcOffset(540).format('**h:mm A** on **dddd MMMM DD, YYYY**')
+        message.channel.send(`It's currently ${japanTime} in Japan.`)
+    }
+}
+
+module.exports = TimeCommand


### PR DESCRIPTION
## Overview
This PR resolves #75 by adding a `$time` command. It simply tells the user what time it is in JST.

## Testing
- [x] Use `$time` and confirm that the time in Japan is correct by checking in Google.
