### PR TITLE
Fix $choose to not include the trigger text

### DIFF
--- a/src/commands/choose.ts
+++ b/src/commands/choose.ts
@@ -1,18 +1,23 @@
 import { Message } from 'discord.js'
 import { SieroCommand } from '../helpers/SieroCommand'
 
+interface ChooseArgs {
+    choices: string
+}
+
 class ChooseCommand extends SieroCommand {
     public constructor() {
         super('choose', {
             aliases: ['choose', 'pick', 'ch'],
-            args: [{ id: 'options' }]
+            args: [{ id: 'choices' }],
+            separator: ';'
         })
     }
 
-    public exec(message: Message) {
+    public exec(message: Message, args: ChooseArgs) {
         this.log(message)
 
-        const options: string[] = this.parseRequest(message.content)
+        const options: string[] = args.choices.split(',').map(Function.prototype.call, String.prototype.trim)
         const hash: number = this.hash(message.author.id + message.content, options.length)
         const choice: string = options[hash]
 
@@ -21,11 +26,6 @@ class ChooseCommand extends SieroCommand {
             `Um... you only gave me one thing to choose from!`
 
         message.reply(reply)
-    }
-
-    private parseRequest(request: string): string[] {
-        const splitRequest: string[] = request.split('?')
-        return splitRequest[splitRequest.length - 1].split(',').map(Function.prototype.call, String.prototype.trim)
     }
 
     private hash(string: string, size: number): number {


### PR DESCRIPTION
## Overview

`$choose` now won't include the trigger text if Siero selects the first option.

## Testing

Add test cases and check the boxes to confirm you have manually confirmed the following cases.
- [ ] In a channel with Siero, send `$choose a, b`. If she replies with `a`, it should not say `$choose a`. If she chooses `b`, try two other choices.
