### PR TITLE
Fix capitalization of gacha commands

### DIFF
--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -22,7 +22,8 @@ export function capitalize(string: string, allWords: boolean = false): string {
 
 export function sanitize(string: string): string {
     let re = /[|;$%@"<>()+]/g
-    return string.replace(re, '').toLowerCase()
+    // return string.replace(re, '').toLowerCase()
+    return string.replace(re, '')
 }
 
 export function intersection(source: string[], destination: string[]): string[] {
@@ -80,7 +81,7 @@ export function parse(request: string) {
     let suffixCross = intersection(parts, suffixes)
 
     // Rebuild the base item name
-    const cleanedName = `${capitalize(parts.join(' '), true)}`
+    const cleanedName = parts.join(' ')
 
     // Reconstruct the item name with its suffixes
     let constructedName = cleanedName

--- a/src/subcommands/gacha/until.ts
+++ b/src/subcommands/gacha/until.ts
@@ -175,9 +175,9 @@ class Until {
 
         var string = ''
         if (rolls.item.recruits != null) {
-            string = `It took **${rolls.count} rolls** to pull **${rolls.item.name} (${rolls.item.recruits})**.`
+            string = `It took **${rolls.count.toLocaleString()} rolls** to pull **${rolls.item.name} (${rolls.item.recruits})**.`
         } else {
-            string = `It took **${rolls.count} rolls** to pull **${rolls.item.name}**.`
+            string = `It took **${rolls.count.toLocaleString()} rolls** to pull **${rolls.item.name}**.`
         }
 
         let numTenPulls = rolls.count / 10


### PR DESCRIPTION
## Overview
Several items have unstandard capitalization and were not accessible via $gacha commands. This removes all auto-capitalization to make the items accessible.

## Testing

Add test cases and check the boxes to confirm you have manually confirmed the following cases.
- [x] In a channel with Siero, send `$gacha until Bab-el-Mandeb flash`. It should find the item and return a value.
- [x] In a channel with Siero, send `$gacha until Jeanne d'Arc (Grand) flash`. It should find the item and return a value.