### PR TITLE
Add Granblue Fes schedule

### DIFF
--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -92,7 +92,8 @@ class ScheduleCommand extends SieroCommand {
         this.message = message
 
         await this.load()
-            .then(() => {
+            .then((data) => {
+                this.schedule = data
                 this.switchOperation(args.operation)
             })
     }
@@ -144,11 +145,11 @@ class ScheduleCommand extends SieroCommand {
     }
 
     // File methods
-    private async load(): Promise<void> {
-        const schedule: string = path.join(__dirname, '..', '..', '..', 'src', 'resources', 'schedule.json')
+    private async load(filename: string = "schedule.json"): Promise<any> {
+        const schedule: string = path.join(__dirname, '..', '..', '..', 'src', 'resources', filename)
         const data: string = await fs.readFile(schedule, 'utf8')
 
-        this.schedule = JSON.parse(data)
+        return JSON.parse(data)
     }
 
     // Page render methods

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -118,6 +118,10 @@ class ScheduleCommand extends SieroCommand {
                 this.show()
                 break
 
+            case 'fes':
+                this.festival()
+                break
+
             case 'next':
                 this.next()
                 break
@@ -133,7 +137,6 @@ class ScheduleCommand extends SieroCommand {
 
         pager.addPage('🕒', this.renderRightNow())
         pager.addPage('📅', this.renderUpcoming())
-        pager.addPage('🎤', await this.renderFestival())
         pager.addPage('🔨', new Page({
             title: 'Planned features',
             description: 'There are no features scheduled to be released'
@@ -157,6 +160,15 @@ class ScheduleCommand extends SieroCommand {
         } else {
             this.message!.channel.send('There is no event scheduled next. Is this the end?')
         }
+    }
+
+    private async festival() {
+        let pager: Pager = new Pager(this.message.author)
+
+        pager.addPage('1️⃣', await this.renderFestival(1))
+        pager.addPage('2️⃣', await this.renderFestival(2))
+
+        pager.render(this.message)
     }
 
     // File methods
@@ -235,20 +247,20 @@ class ScheduleCommand extends SieroCommand {
         }])
     }
 
-    private async renderFestival(): Promise<Page> {
-        const sections = await this.renderFestivalSections()
+    private async renderFestival(day: number): Promise<Page> {
+        const sections = await this.renderFestivalSections(day)
 
         return new Page({
-            title: 'Granblue Fes 2020'
+            title: 'Granblue Fes 2020',
+            image: 'https://images-ext-2.discordapp.net/external/Zky9CQAg3g7hdOQR_w7YbIaqy6FRh6P5mnZAvEQEu4g/https/fes.granbluefantasy.jp/assets2020/images/share/ogp.jpg'
         }, sections)
     }
 
-    private async renderFestivalSections(): Promise<Section[]> {
+    private async renderFestivalSections(day: number): Promise<Section[]> {
         return await this.load('festival.json')
             .then((data) => {
                 const festival: FestivalEvent[] = data.events
-                let day1: Section[] = []
-                let day2: Section[] = []
+                let events: Section[] = []
 
                 for (let i in festival) {
                     const event = festival[i]
@@ -266,13 +278,8 @@ class ScheduleCommand extends SieroCommand {
                         let castString = (event.cast) ? event.cast.map(member => `${member.name} (${member.role})`).join('\n') : null
                         let value: string = `\`\`\`html\n${castString ? castString + '\n\n' : ''}${dateString}\n\`\`\``
                         
-                        if (event.day == 1) {
-                            day1.push({
-                                name: event.name.en,
-                                value: value
-                            })
-                        } else if (event.day == 2) {
-                            day2.push({
+                        if (event.day == day) {
+                            events.push({
                                 name: event.name.en,
                                 value: value
                             })
@@ -280,17 +287,15 @@ class ScheduleCommand extends SieroCommand {
                     }
                 }
 
-                day1.unshift({
-                    name: 'Day 1',
-                    value: 'Watch → https://www.youtube.com/watch?v=gEIfjAoqKjE'
+                const link1 = 'https://www.youtube.com/watch?v=gEIfjAoqKjE'
+                const link2 = 'https://www.youtube.com/watch?v=Kb8ChL3ABZA'
+
+                events.unshift({
+                    name: `Day ${day}`,
+                    value: `Watch → ${(day == 1) ? link1 : link2}`
                 })
 
-                day1.push({
-                    name: 'Day 2',
-                    value: 'Watch → https://www.youtube.com/watch?v=Kb8ChL3ABZA'
-                })
-
-                return day1.concat(day2)
+                return events
             })
     }
 

--- a/src/resources/festival.json
+++ b/src/resources/festival.json
@@ -1,0 +1,287 @@
+{
+    "events": [
+        {
+            "name": {
+                "en": "Opening",
+                "jp": "オープニング"
+            },
+            "day": 1,
+            "starts": "2020-12-12T13:30:00+09:00",
+            "ends": "2020-12-12T13:45:00+09:00",
+            "cast": [
+                {
+                    "name": "Ono Yuuki",
+                    "role": "Gran/Lancelot/Sagittarius"
+                },
+                {
+                    "name": "Katou Emiri",
+                    "role": "Sierokarte/Halluel and Malluel"
+                },
+                {
+                    "name": "Touyama Nao",
+                    "role": "Lyria"
+                },
+                {
+                    "name": "Kawahara Yoshihisa",
+                    "role": "Tyre"
+                },
+                {
+                    "name": "Tachibana Rika",
+                    "role": "Yuisis"
+                },
+                {
+                    "name": "Kimura Yuito",
+                    "role": "Producer"
+                },
+                {
+                    "name": "Fukuhara Tetsuya",
+                    "role": "Game Director"
+                }
+            ]
+        },
+        {
+            "name": {
+                "en": "Granblue Until Now 2020",
+                "jp": "これまでのグランブルーファンタジー2020"
+            },
+            "day": 1,
+            "starts": "2020-12-12T13:45:00+09:00",
+            "ends": "2020-12-12T14:45:00+09:00",
+            "cast": [
+                {
+                    "name": "Katou Emiri",
+                    "role": "Sierokarte/Halluel and Malluel"
+                },
+                {
+                    "name": "Touyama Nao",
+                    "role": "Lyria"
+                },
+                {
+                    "name": "Shiraishi Minoru",
+                    "role": "Lowain"
+                },
+                {
+                    "name": "Imai Asami",
+                    "role": "Vira"
+                },
+                {
+                    "name": "Kimura Yuito",
+                    "role": "Producer"
+                },
+                {
+                    "name": "Fukuhara Tetsuya",
+                    "role": "Game Director"
+                }
+            ]
+        },
+        {
+            "name": {
+                "en": "Official Cosplay Stage",
+                "jp": "オフィシャルキャストステージ"
+            },
+            "day": 1,
+            "starts": "2020-12-12T15:00:00+09:00",
+            "ends": "2020-12-12T16:00:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Granblue TV Channel Fes Edition",
+                "jp": "ぐらぶるTVちゃんねるっ！フェス出張版"
+            },
+            "day": 1,
+            "starts": "2020-12-12T16:15:00+09:00",
+            "ends": "2020-12-12T19:15:00+09:00",
+            "cast": [
+                {
+                    "name": "Ono Yuuki",
+                    "role": "Gran/Lancelot/Sagittarius"
+                },
+                {
+                    "name": "Katou Emiri",
+                    "role": "Sierokarte/Halluel and Malluel"
+                },
+                {
+                    "name": "Touyama Nao",
+                    "role": "Lyria"
+                },
+                {
+                    "name": "Kazuhiko Inoue",
+                    "role": "Siegfried"
+                },
+                {
+                    "name": "Tetsu Inada",
+                    "role": "Ladiva"
+                },
+                {
+                    "name": "Fukuyama Jun",
+                    "role": "Katoru"
+                },
+                {
+                    "name": "Imai Asami",
+                    "role": "Vira"
+                },
+                {
+                    "name": "Shiraishi Minoru",
+                    "role": "Lowain"
+                },
+                {
+                    "name": "Yonezawa Madoka",
+                    "role": "Ferry"
+                },
+                {
+                    "name": "Eguchi Takuya",
+                    "role": "Vane"
+                },
+                {
+                    "name": "Osaka Ryota",
+                    "role": "Percival"
+                },
+                {
+                    "name": "Kimura Yuito",
+                    "role": "Producer"
+                },
+                {
+                    "name": "Fukuhara Tetsuya",
+                    "role": "Game Director"
+                }
+            ]
+        },
+        {
+            "name": {
+                "en": "Granblue Night Party (Paid)",
+                "jp": "グラブルナイトパーティー (課金)"
+            },
+            "day": 1,
+            "starts": "2020-12-12T21:00:00+09:00",
+            "ends": "2020-12-12T19:23:30+09:00",
+            "cast": [
+                
+            ]
+        },
+        {
+            "name": {
+                "en": "Stella Magna Special Live in Granblue Fes 2020",
+                "jp": "Stella Magna スペシャルライブinグラブルフェス2020"
+            },
+            "day": 2,
+            "starts": "2020-12-13T14:00:00+09:00",
+            "ends": "2020-12-13T15:10:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Granblue Q&A",
+                "jp": "グラブルQ&A"
+            },
+            "day": 2,
+            "starts": "2020-12-13T15:10:00+09:00",
+            "ends": "2020-12-13T16:40:00+09:00",
+            "cast": [
+                {
+                    "name": "Ono Yuuki",
+                    "role": "Gran/Lancelot/Sagittarius"
+                },
+                {
+                    "name": "Katou Emiri",
+                    "role": "Sierokarte/Halluel and Malluel"
+                },
+                {
+                    "name": "Touyama Nao",
+                    "role": "Lyria"
+                },
+                {
+                    "name": "Nakamura Yuuichi",
+                    "role": "Romeo/Tsubasa"
+                },
+                {
+                    "name": "Kimura Yuito",
+                    "role": "Producer"
+                },
+                {
+                    "name": "Fukuhara Tetsuya",
+                    "role": "Game Director"
+                }
+            ]
+        },
+        {
+            "name": {
+                "en": "Granblue Fes Special Character Live",
+                "jp": "グラブルフェス Special Character Live"
+            },
+            "day": 2,
+            "starts": "2020-12-13T16:40:00+09:00",
+            "ends": "2020-12-13T18:00:00+09:00"
+        },
+        {
+            "name": {
+                "en": "Granblue Special Christmas Livestream",
+                "jp": "グラブル生放送 クリスマス特別版"
+            },
+            "day": 2,
+            "starts": "2020-12-13T18:30:00+09:00",
+            "ends": "2020-12-13T21:30:00+09:00",
+            "cast": [
+                {
+                    "name": "Ono Yuuki",
+                    "role": "Gran/Lancelot/Sagittarius"
+                },
+                {
+                    "name": "Katou Emiri",
+                    "role": "Sierokarte/Halluel and Malluel"
+                },
+                {
+                    "name": "Touyama Nao",
+                    "role": "Lyria"
+                },
+                {
+                    "name": "Ueda Kana",
+                    "role": "Yuel"
+                },
+                {
+                    "name": "Shiraishi Ryoko",
+                    "role": "Societte"
+                },
+                {
+                    "name": "Nakamura Yuuichi",
+                    "role": "Romeo/Tsubasa"
+                },
+                {
+                    "name": "Kawahara Yoshihisa",
+                    "role": "Tyre"
+                },
+                {
+                    "name": "Takanori Hoshino",
+                    "role": "Dante"
+                },
+                {
+                    "name": "Tachibana Rika",
+                    "role": "Yuisis"
+                },
+                {
+                    "name": "M・A・O",
+                    "role": "Narmaya"
+                },
+                {
+                    "name": "Osaka Ryota",
+                    "role": "Percival"
+                },
+                {
+                    "name": "Kimura Yuito",
+                    "role": "Producer"
+                },
+                {
+                    "name": "Fukuhara Tetsuya",
+                    "role": "Game Director"
+                }
+            ]
+        },
+        {
+            "name": {
+                "en": "Granblue Fes 2020 Special Show: The Stars of the Sky",
+                "jp": "グラブルフェス2020 スペシャルショー 蒼の奇跡-The Stars of the Sky-"
+            },
+            "day": 2,
+            "starts": "2020-12-13T21:45:00+09:00",
+            "ends": "2020-12-13T22:35:00+09:00"
+        }
+    ]
+}


### PR DESCRIPTION
## Overview

This adds a command to see the Granblue Fes schedule. While it was made for the 2020 festival, in the future, `festival.json` can be updated for other events.

## Testing

Add test cases and check the boxes to confirm you have manually confirmed the following cases.
- [ ] In a channel with Siero, send `$schedule fes`. Observe she replies with a pager embed.
