### PR TITLE
Convert $spark to use pager and use default rateup

### DIFF
--- a/src/commands/gacha.ts
+++ b/src/commands/gacha.ts
@@ -237,11 +237,20 @@ class GachaCommand extends SieroCommand {
     // Data methods
     private async storeRateups() {
         const sourceUser: User = this.message.mentions.users.values().next().value
+        
         this.rateups = await Rateup.fetch(this.message.author.id, this.message)
             .catch((error: Error) => {
                 const text = `Sorry, there was an error communicating with the database to copy ${sourceUser}'s rate-up.`
                 this.reportError(error.message, text)
             })
+        
+        if (this.rateups.length == 0) {
+            this.rateups = await Rateup.fetch(this.client.user?.id)
+                .catch((error: Error) => {
+                    const text = `Sorry, there was an error communicating with the database to fetch the default rate-up.`
+                    this.reportError(error.message, text)
+                })
+        }
     }
 
     private async storeSparkTarget() {


### PR DESCRIPTION
## Overview
The `$spark` command now has a pager. The second page shows the rateup being used for the calculation. Also, if a user does not have a rateup set, their rolls will now automatically use the bot's rateup.

## Testing

Add test cases and check the boxes to confirm you have manually confirmed the following cases.
- [x] In a channel with Siero, send `$gacha spark`. Observe that the response has a pager (emoji that when clicked change the embed contents).
- [x] In a channel with Siero, send `$gacha rateup clear`, followed by `$gacha spark`. Observe that the rateup is using the bot's rateup.
