### PR TITLE
Fix leaderboard

### DIFF
--- a/src/commands/gacha.ts
+++ b/src/commands/gacha.ts
@@ -134,20 +134,19 @@ class GachaCommand extends SieroCommand {
         let gacha = new Gacha(this.args.gala, this.args.season, this.rateups)
         let items = gacha.spark()
 
-        const siero = (this.message.author.id === this.client.ownerID) ? this.client.user : null
-        const rateup = new Rateup(this, this.message, siero)
+        const rateup = new Rateup(this, this.message, this.client.user)
         await rateup.setup()
 
-        let author: User
-        if (siero && this.defaultRateups) {
-            author = siero
+        let username: string
+        if (this.defaultRateups) {
+            username = (this.client.user) ? this.client.user.username : 'Siero'
         } else {
-            author = this.message.author
+            username = this.message.author.username
         }
         
         let pager: Pager = new Pager(this.message.author)
         pager.addPage('✨', this.renderSpark(items))
-        pager.addPage('📈', rateup.renderPage(this.rateups, author.username))
+        pager.addPage('📈', rateup.renderPage(this.rateups, username))
 
         pager.render(this.message)
     }

--- a/src/commands/spark.ts
+++ b/src/commands/spark.ts
@@ -1,4 +1,4 @@
-import { GuildMember, Message, MessageEmbed, Snowflake, User } from 'discord.js'
+import { Message, MessageEmbed, User } from 'discord.js'
 import { SieroCommand } from '../helpers/SieroCommand'
 
 const { Client, pgpErrors } = require('../services/connection.js')
@@ -72,6 +72,12 @@ class SparkCommand extends SieroCommand {
                 }
 
                 return
+            }).then(() => {
+                // This is for our manual saving of members for leaderboards.
+                // Discord won't give us permission to read the member list.
+                if (message.channel.type !== 'dm') {
+                    this.checkGuildAssociation(this.commandType)
+                }
             }).then(() => {
                 this.switchOperation(args)
             })
@@ -233,8 +239,9 @@ class SparkCommand extends SieroCommand {
         const guild = this.message.guild
 
         if (guild) {
-            let memberIds: Snowflake[] = (await guild.members.fetch()).map((g: GuildMember) => g.id);
-            let leaderboard = new Leaderboard(memberIds, order)
+            // This is disabled for now since Discord won't give us the permissions to fetch the member list
+            // let memberIds: Snowflake[] = (await guild.members.fetch()).map((g: GuildMember) => g.id);
+            let leaderboard = new Leaderboard(this.message.guild?.id, order)
             await leaderboard.fetchData()
                 .then((embed: string) => {
                     this.message.channel.send(embed)
@@ -512,6 +519,48 @@ class SparkCommand extends SieroCommand {
                 .catch((error: Error) =>  {
                     console.error(error)
                 })
+        } catch(error) {
+            console.error(error)
+        }
+    }
+
+    private checkGuildAssociation(table: string) {
+        let sql = [
+            `SELECT user_id, guild_ids FROM ${table}`,
+            'WHERE user_id = $1',
+            'LIMIT 1'
+        ].join(' ')
+
+        try {
+            Client.one(sql, this.message.author.id)
+                .then((result: StringResult) => {
+                    let guilds = result.guild_ids
+                    if (!guilds || guilds && this.message.guild && !guilds.includes(this.message.guild.id)) {
+                        this.createGuildAssociation(table)
+                    }
+                })
+                .catch((error: Error) => {
+                    console.error(error)
+                })
+        } catch(error) {
+            console.error(error)
+        }
+    }
+
+    private createGuildAssociation(table: string) {
+        let sql = [
+            `UPDATE ${table}`,
+            'SET guild_ids = array_cat(guild_ids, $1)',
+            'WHERE user_id = $2'
+        ].join(' ')
+
+        try {
+            if (this.message.guild) {
+                Client.any(sql, ['{' + this.message.guild.id + '}', this.message.author.id])
+                    .catch((error: Error) => {
+                        console.error(error)
+                    })
+            }
         } catch(error) {
             console.error(error)
         }

--- a/src/resources/dbupdate_v5.0.pgsql
+++ b/src/resources/dbupdate_v5.0.pgsql
@@ -1,0 +1,1 @@
+ALTER TABLE sparks ADD COLUMN guild_ids TEXT[];


### PR DESCRIPTION
## Overview
Reverts #82 since Discord will not give us permission to read the member list in servers. This is insecure! We don't actually want to be storing guild ids, but they don't give us any choice.

## Testing

Add test cases and check the boxes to confirm you have manually confirmed the following cases.
- [ ] In a channel with Siero, send `$spark leaderboard`. Observe she replies with a leaderboard of spark progress.
- [ ] In a channel with Siero, send `$spark loserboard`. Observe she replies with a reverse leaderboard of spark progress.
