### PR TITLE
Update leaderboard to wrap text gracefully

### DIFF
--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -114,7 +114,7 @@ export function mapRarity(rarity: number): string | null {
 export function spacedString(string: string, maxNumChars: number) {
     if (string) {
         let numSpaces = maxNumChars - string.length
-        var spacedString = string
+        let spacedString = string
 
         for (var i = 0; i < numSpaces; i++) {
             spacedString += " "
@@ -122,7 +122,20 @@ export function spacedString(string: string, maxNumChars: number) {
 
         return spacedString
     } else {
-        return ''
+        let spacedString = ''
+        
+        for (var i = 0; i < maxNumChars; i++) {
+            spacedString += " "
+        }
+
+        return spacedString
+    }
+}
+
+export function splitString(string: string, maxNumChars: number) {
+    return {
+        string1: string.substr(0, maxNumChars), 
+        string2: string.substr(maxNumChars)
     }
 }
 

--- a/src/subcommands/spark/leaderboard.ts
+++ b/src/subcommands/spark/leaderboard.ts
@@ -1,7 +1,7 @@
 import { MessageEmbed } from 'discord.js'
 
 import { Client } from '../../services/connection'
-import { spacedString } from '../../helpers/common'
+import { spacedString, splitString } from '../../helpers/common'
 
 interface Result {
     username: string,
@@ -66,35 +66,57 @@ class Leaderboard {
             let maxRows = (rows.length > 10) ? 10 : rows.length
 
             let usernameMaxChars = 14
-            let numDrawsMaxChars = 11
-            let targetMaxChars = 16
+            let numDrawsMaxChars = 10
+            let targetMaxChars = 17
 
-            let divider = '+-----+' + '-'.repeat(usernameMaxChars + 2) + '+' + '-'.repeat(numDrawsMaxChars + 1) + '+' + '-'.repeat(targetMaxChars + 2) + '+\n'
+            let divider = '+----+' + '-'.repeat(usernameMaxChars + 2) + '+' + '-'.repeat(numDrawsMaxChars + 2) + '+' + '-'.repeat(targetMaxChars + 2) + '+\n'
             var result = divider
 
             for (var i = 0; i < maxRows; i++) {
+                let rowHeight = 1
+
+                let place = ((i + 1) < 10) ? `${i + 1}` : `${i + 1}`
+
                 let numDraws = this.calculateDraws(rows[i].crystals, rows[i].tickets, rows[i].ten_tickets)
 
                 let spacedUsername = spacedString(rows[i].username, usernameMaxChars)
                 let spacedDraws = spacedString(`${numDraws} draws`, numDrawsMaxChars)
 
-                var spacedTarget = ''
+                let target: string
                 if (rows[i].recruits == null && rows[i].name == null && rows[i].target_memo != null) {
-                    spacedTarget = spacedString(`${rows[i].target_memo} (U)`, targetMaxChars)
+                    target = rows[i].target_memo
                 } else if (rows[i].recruits != null || rows[i].name != null) {
-                    if (rows[i].recruits != null) {
-                        spacedTarget = spacedString(rows[i].recruits, targetMaxChars)
-                    } else if (rows[i].name != null) {
-                        spacedTarget = spacedString(rows[i].name, targetMaxChars)
-                    }
+                    target = rows[i].recruits
                 } else {
-                    spacedTarget = spacedString('', targetMaxChars)
+                    target = ''
                 }
 
-                let place = ((i + 1) < 10) ? `${i + 1}  ` : `${i + 1} `
+                if (target.length > targetMaxChars) {
+                    rowHeight = 2
+                }
 
-                result += `| #${place}| ${spacedUsername} | ${spacedDraws}| ${spacedTarget} |\n`
-                result += divider
+
+                switch (rowHeight) {
+                    case 1:
+                        const spacedTarget = spacedString(target, targetMaxChars)
+                        result += `| #${place} | ${spacedUsername} | ${spacedDraws} | ${spacedTarget} |\n`
+                        result += divider
+                        break
+
+                    case 2:
+                        const splitTarget = splitString(target, targetMaxChars)
+                        const spacedString2 = spacedString(splitTarget.string2, targetMaxChars)
+                        const stringBeginning = `| #${place} | ${spacedUsername} | ${spacedDraws}`
+
+                        result += `${stringBeginning} | ${splitTarget.string1} |\n`
+                        result += `|${' '.repeat(4)}|${' '.repeat(usernameMaxChars + 2)}|${' '.repeat(numDrawsMaxChars + 2)}| ${spacedString2} |\n`
+                        result += divider
+                        break
+
+                    default:
+                        break
+                
+                }
             }
             
             return new MessageEmbed({


### PR DESCRIPTION
## Overview
This updates the leaderboard to use two rows when a spark target has a long name.

## Testing

Add test cases and check the boxes to confirm you have manually confirmed the following cases.
- [ ] In a channel with Siero, send `$s leaderboard` after setting a long target like `Jeanne d'Arc (Grand)`. Observe that your row in the leaderboard takes up two rows.