### PR TITLE
Allow users to directly query upcoming schedule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -571,7 +571,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -2226,7 +2225,6 @@
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.2.tgz",
       "integrity": "sha512-/i4fX1ss+Dtwyk++OsAI6SEV+eE1dvI6W+0hORdjfruQ7VD5uYTetJIHcEMjWiEiszWjn2aAtP1CB/Q4KfeoYA==",
       "dependencies": {
-        "encoding": "^0.1.12",
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.0.0"

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -126,13 +126,16 @@ class ScheduleCommand extends SieroCommand {
                 this.next()
                 break
 
+            case 'upcoming':
+                this.upcoming()
+                break
+
             default:
                 break
         }
     }
 
-    // Command methods
-    private async show() {        
+    private createPager(): Pager {
         let pager: Pager = new Pager(this.message.author)
 
         pager.addPage('🕒', this.renderRightNow())
@@ -148,6 +151,12 @@ class ScheduleCommand extends SieroCommand {
 
         pager.addPage('❓', this.renderHelp())
 
+        return pager
+    }
+
+    // Command methods
+    private async show() {        
+        let pager: Pager = this.createPager()
         pager.render(this.message)
     }
 
@@ -160,6 +169,12 @@ class ScheduleCommand extends SieroCommand {
         } else {
             this.message!.channel.send('There is no event scheduled next. Is this the end?')
         }
+    }
+
+    private async upcoming() {
+        let pager: Pager = this.createPager()
+        pager.selectPage('📅')
+        pager.render(this.message)
     }
 
     private async festival() {

--- a/src/services/pager.ts
+++ b/src/services/pager.ts
@@ -19,7 +19,8 @@ export class Pager {
     embed: MessageEmbed | null = null
     message: Message | null = null
     originalUser: User
-
+    hasRendered: boolean = false
+       
     public constructor(user: User, pages: PageMap = {}) {
         this.pages = pages
         this.originalUser = user
@@ -33,14 +34,21 @@ export class Pager {
     }
 
     public async selectPage(selectedKey: string): Promise<void> {
+        console.log("Page being selected...")
+
         if (this.pages[selectedKey]) {
+            console.log("Key found!")
             for (const [_, value] of Object.entries(this.pages)) {
                 value.selected = false
             }
 
             this.pages[selectedKey].selected = true
 
-            await this.update(selectedKey)
+            console.log(selectedKey, this.pages[selectedKey].selected)
+
+            if (this.hasRendered) {
+                await this.update(selectedKey)
+            }
         }
     }
 
@@ -55,6 +63,8 @@ export class Pager {
     }
 
     public render(message: Message) {
+        console.log("Rendering...")
+
         let embed: MessageEmbed = new MessageEmbed
         const selectedPage: Page = this.selectedPage()
 
@@ -79,6 +89,7 @@ export class Pager {
             .then((sentMessage: Message) => {
                 this.message = sentMessage
                 this.addReactions()
+                this.hasRendered = true
             })
             .catch((error: Error) => {
                 console.error(`Unable to send message due to error: ${error}`)
@@ -158,11 +169,15 @@ export class Pager {
         }
     }
 
-    private selectedPage(): Page {
+    public selectedPage(): Page {
         const defaultPage: Page = this.pages[Object.keys(this.pages)[0]].page
         const selectedPage: Page | undefined = Object.entries(this.pages).map((entry: [string, PageEntry]) => {
+            console.log(entry[1].selected)
             return (entry[1].selected) ? entry[1].page : undefined
-        })[0]
+        })[1]
+        
+
+        console.log(selectedPage)
 
         if (selectedPage) {
             return selectedPage


### PR DESCRIPTION
## Overview

Users can now directly query the upcoming schedule with `$schedule upcoming`

## Testing

- [ ] In a channel with Siero, send `$schedule upcoming`. Observe she replies with the upcoming schedule.
