### PR TITLE
Fix gacha probabilities

### DIFF
--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -126,7 +126,7 @@ class Cache {
 	}
 
 	public fetchLimited(gala: string) {
-		const list = this.characterWeapons(Rarity.SSR, gala, null)
+		const list = this.limitedWeapons(gala)
 		const r = Math.floor(Math.random() * list.length)
 
 		return list[r]

--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -111,22 +111,22 @@ class Cache {
 		return set[rand]
 	}
 
-	public fetchWeapon(rarity: Rarity, season: string | null = null) {
-		const list = this.characterWeapons(rarity, null, season)
+	public fetchWeapon(rarity: Rarity, season: string | null = null, exclusions: Item[]) {
+		const list = this.characterWeapons(rarity, null, season).filter((item: Item) => !exclusions.includes(item))
 		const r = Math.floor(Math.random() * list.length)
 
 		return list[r]
 	}
 
-	public fetchSummon(rarity: Rarity, season: string | null = null) {
-		const list = this.summons(rarity, null, season)
+	public fetchSummon(rarity: Rarity, season: string | null = null, exclusions: Item[]) {
+		const list = this.summons(rarity, null, season).filter((item: Item) => !exclusions.includes(item))
 		const r = Math.floor(Math.random() * list.length)
 
 		return list[r]
 	}
 
-	public fetchLimited(gala: string) {
-		const list = this.limitedWeapons(gala)
+	public fetchLimited(gala: string, exclusions: Item[]) {
+		const list = this.limitedWeapons(gala).filter((item: Item) => !exclusions.includes(item))
 		const r = Math.floor(Math.random() * list.length)
 
 		return list[r]

--- a/src/services/gacha.ts
+++ b/src/services/gacha.ts
@@ -258,13 +258,13 @@ export class Gacha {
             // pick a random item from that bucket
             switch(bucket) {
                 case GachaBucket.WEAPON:
-                    item = cache.fetchWeapon(rarity, this.season) 
+                    item = cache.fetchWeapon(rarity, this.season, this.rateups) 
                     break
                 case GachaBucket.SUMMON:
-                    item = cache.fetchSummon(rarity, this.season)
+                    item = cache.fetchSummon(rarity, this.season, this.rateups)
                     break
                 case GachaBucket.LIMITED:
-                    item = cache.fetchLimited(this.gala)
+                    item = cache.fetchLimited(this.gala, this.rateups)
                     break
             }
         } else {

--- a/src/services/gacha.ts
+++ b/src/services/gacha.ts
@@ -361,20 +361,26 @@ export class Gacha {
 
     private determineSSRBucket(rates: CategoryMap): number {
         // Calculate the total rate of all rateup items
-        let rateupSum: number = 0
+        let allRateups: number = 0
         for (let i in this.rateups) {
             // TODO: Why won't these add as numbers if they are technically numbers?
             let item: Item = this.rateups[i]
-            rateupSum = rateupSum + parseFloat(item.rate as string)
+            allRateups = allRateups + parseFloat(item.rate as string)
         }
 
+        let limitedRate = rates.limited.rate * rates.limited.count
+        let summonRate = rates.summon.rate * rates.summon.count
+        let weaponRate = rates.weapon.rate * rates.weapon.count
+
         // Store all the rates
+        // allRateups = 1
         let bucketRates = [
-            rateupSum, 
-            rates.limited.rate * rates.limited.count, 
-            rates.summon.rate * rates.summon.count, 
-            rates.weapon.rate * rates.weapon.count
+            1,
+            limitedRate / allRateups,
+            summonRate  / allRateups,
+            weaponRate  / allRateups
         ]
+
         let bucketKeys = [GachaBucket.RATEUP, GachaBucket.LIMITED, GachaBucket.SUMMON, GachaBucket.WEAPON]
 
         // Use Chance.js to determine a bucket

--- a/src/services/gacha.ts
+++ b/src/services/gacha.ts
@@ -274,6 +274,26 @@ export class Gacha {
             item = this.rateups.find(item => item.name == result)!
         }
 
+        // Debug what is being pulled by uncommenting this line
+        // let bucketName = ''
+        // switch (bucket) {
+        //     case 1:
+        //         bucketName = 'Weapon'
+        //         break
+        //     case 2:
+        //         bucketName = 'Summon'
+        //         break
+        //     case 3:
+        //         bucketName = 'Limited'
+        //         break
+        //     case 4:
+        //         bucketName = 'Rate-up'
+        //         break
+        //     default:
+        //         break
+        // }
+        // console.log(`${bucketName}: ${item.name}`)
+
         return item
     }
 


### PR DESCRIPTION
## Overview
There was an issue where it was seemingly (and actually) impossible to roll limited units that were not rate up.

Upon investigation, there were two issues:

1. The method being used to pull all limited character weapons was not working correctly. It was pulling a list of all character weapons, including limited character weapons, which is incorrect. This led to normal gacha weapons being returned when requesting a limited character weapon.
2. Rateup items were not being excluded from their normal buckets. This means that if Sky Ace were rateup, that item would be able to be returned as a rateup item (0.3%) as well as a limited item (something like 0.15%), significantly and incorrectly increasing the odds that the weapon is drawn.

## Testing

Add test cases and check the boxes to confirm you have manually confirmed the following cases.
- [x] Enable the debug code in `services/gacha.js`
- [x] In a channel with Siero, send `$gacha spark legend` or `$gacha spark flash` with an active rateup. You'll have to send the command several times, but ensure that the output in the command line matches the buckets the weapons should appear in.
