### PR TITLE
Fix non-character weapons missing from gacha pool

### DIFF
--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -248,7 +248,7 @@ class Cache {
         "gacha.halloween",
         "gacha.holiday",
       ])
-      .where("recruits", "is not", null)
+      .where("recruits", "is", null)
       .where("rarity", "=", rarity)
       .execute()
 


### PR DESCRIPTION
## Summary
- `fetchNonCharacterWeapons` used `WHERE recruits IS NOT NULL`, same as `fetchCharacterWeapons`
- This meant non-character weapons were never loaded into the cache — the gacha pool was missing all of them
- Fix: change to `WHERE recruits IS NULL` so weapons without a recruited character are correctly fetched

## Test plan
- [ ] Verify gacha rolls include non-character weapons (e.g. R/SR weapons without a recruitable character)
- [ ] Verify character weapons still appear correctly